### PR TITLE
Add nextjs config file

### DIFF
--- a/src/nextjs/assets/next.config.js
+++ b/src/nextjs/assets/next.config.js
@@ -1,0 +1,36 @@
+const jsonConfig = require('./next.config.json')
+delete jsonConfig['//']
+
+/**
+ * Picks env variables with keys starting with `term`.
+ * @param {string} [term] - A starting term of a key to pick.
+ * @returns {Record<string, string>}
+ */
+function pickEnvironmentByKey(term) {
+  return Object.entries(process.env).reduce(
+    (result, [key, value]) => {
+      if (key.startsWith(term)) {
+        result[key] = value
+      }
+
+      return result
+    },
+
+    {},
+  )
+}
+
+/**
+ * @type {import('next').NextConfig}
+ */
+const config = {
+  ...jsonConfig,
+  serverRuntimeConfig: pickEnvironmentByKey('NEXT_SERVER_'),
+}
+
+config.publicRuntimeConfig = {
+  ...(config.publicRuntimeConfig || {}),
+  ...pickEnvironmentByKey('NEXT_PUBLIC_'),
+}
+
+module.exports = config

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -75,6 +75,27 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
       })
     })
 
+    // ANCHOR NextJS config
+    new AssetFile(this, 'next.config.js', {sourcePath: path.join(assetsDir, 'next.config.js')})
+
+    new projen.JsonFile(this, 'next.config.json', {
+      obj: {
+        images: {formats: ['avif', 'webp'].map((type) => `image/${type}`)},
+        output: 'standalone',
+        poweredByHeader: false,
+
+        publicRuntimeConfig: {
+          ACCEPT_IMAGES_MIME_TYPES: ['avif', 'gif', 'jpeg', 'png', 'svg+xml', 'webp']
+            .map((type) => `image/${type}`)
+            .join(', '),
+          ITEMS_PER_PAGE: 25,
+          US_DATE_FORMAT: 'MM/DD/YYYY',
+        },
+
+        reactStrictMode: true,
+      },
+    })
+
     // ANCHOR ESLint and prettier setup
     this.package.addField('prettier', '@ottofeller/prettier-config-ofmt')
     this.package.addField('eslintConfig', {extends: ['@ottofeller/eslint-config-ofmt/eslint.quality.cjs']})
@@ -100,10 +121,7 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
       )
 
       // ANCHOR Codegen
-      new AssetFile(this, 'codegen.yml', {
-        sourcePath: path.join(assetsDir, 'codegen.yml'),
-      })
-
+      new AssetFile(this, 'codegen.yml', {sourcePath: path.join(assetsDir, 'codegen.yml')})
       this.addTask('generate-graphql-schema', {exec: 'npx apollo schema:download'})
       this.addTask('gql-to-ts', {exec: 'graphql-codegen -r dotenv/config --config codegen.yml'})
     }
@@ -115,22 +133,12 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
       marker: false,
     })
 
-    new AssetFile(this, 'tailwind.config.js', {
-      sourcePath: path.join(assetsDir, 'tailwind.config.js'),
-    })
+    new AssetFile(this, 'tailwind.config.js', {sourcePath: path.join(assetsDir, 'tailwind.config.js')})
 
     // ANCHOR Docker setup
-    new projen.TextFile(this, '.dockerignore', {
-      lines: [GENERATED_BY_PROJEN, 'node_modules', '.next'],
-    })
-
-    new AssetFile(this, 'Dockerfile.dev', {
-      sourcePath: path.join(assetsDir, 'Dockerfile.dev'),
-    })
-
-    new AssetFile(this, 'Dockerfile.production', {
-      sourcePath: path.join(assetsDir, 'Dockerfile.production'),
-    })
+    new projen.TextFile(this, '.dockerignore', {lines: [GENERATED_BY_PROJEN, 'node_modules', '.next']})
+    new AssetFile(this, 'Dockerfile.dev', {sourcePath: path.join(assetsDir, 'Dockerfile.dev')})
+    new AssetFile(this, 'Dockerfile.production', {sourcePath: path.join(assetsDir, 'Dockerfile.production')})
 
     // ANCHOR VSCode settings
     VsCodeSettings.addToProject(this)


### PR DESCRIPTION
Closes PLA-129.

Since `nextjs` doc says the config `is a regular Node.js module, not a JSON file`, I've created a JS file similar to the nexus-ts-template. The stable part of the exported object imported from a separate JSON file. The latter is created with regular `projen` toolset and thus is editable from `.projenrc.ts`.

The following properties are not supported by current version of `nextjs` config and therefore not included:
- cssLoaderOptions.localIdentName,
- cssModules.
Seems like they shall be defined in a webpack config. Do we need them?