### PR TITLE
Update pattern for included assets

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,7 +12,7 @@ tsconfig.dev.json
 !*.d.ts
 
 # Include assets
-!src/**/assets/*
+!src/**/assets/**/*
 
 # Exclude jsii outdir
 dist


### PR DESCRIPTION
With the previous version of the pattern .ts files within assets folders are excluded. The updated version allows for copying any files.