### PR TITLE
Update content field of the tailwind config to point to src folder

### DIFF
--- a/src/nextjs/tailwind-static-config.ts
+++ b/src/nextjs/tailwind-static-config.ts
@@ -1,5 +1,5 @@
 export const tailwindStaticConfig = {
-  content: ['./pages/**/*.tsx'],
+  content: ['./src/**/*.tsx'],
 
   theme: {
     borderRadius: {


### PR DESCRIPTION
Closes PLA-140.

The projects use the "pages" folder only to reexport components stored in "src" folder. The config should point to the path where actual components reside.