### PR TITLE
Wrap ofmt inputs with quates

### DIFF
--- a/src/common/lint/add-lint-scripts.ts
+++ b/src/common/lint/add-lint-scripts.ts
@@ -1,10 +1,8 @@
 import {NodeProject} from 'projen/lib/javascript'
 
 export const addLintScripts = (project: NodeProject, lintPaths: Array<string>): void => {
-  project.setScript('format', lintPaths.map((lintPath) => `ofmt ${lintPath}`).join(' && '))
+  const joinedPaths = lintPaths.join(' ')
+  project.setScript('format', `ofmt "${joinedPaths}"`)
   project.setScript('typecheck', 'tsc --noEmit --project tsconfig.dev.json')
-
-  // TODO Update to a single call with multiple inputs when the ofmt package is able to handle it.
-  const ofmtLint = lintPaths.map((lintPath) => `ofmt --lint ${lintPath}`).join(' && ')
-  project.setScript('lint', `${ofmtLint} && olint ${lintPaths.join(' ')}`)
+  project.setScript('lint', `ofmt --lint "${joinedPaths}" && olint ${joinedPaths}`)
 }


### PR DESCRIPTION
This way ofmt can be called once on multiples dirs instead of multiple calls one path at a time.