### PR TITLE
Add status badge for the test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # OttoFeller Projen Templates
+![Test workflow status](https://github.com/ottofeller/templates/actions/workflows/test.yml/badge.svg?branch=main)
+
 ## 📀 User guide
 In order to install a certain project (template) from `@ottofeller/templates` call `npx projen new` in the dir of the new project in the following way:
 ```sh


### PR DESCRIPTION
Closes PLA-182.

The parameter `?branch=main` is added to force showing only the main branch status. Otherwise the most recent run would be shown, that is not always related to the main branch.