### PR TITLE
PLA-222 Remove idea folder from nextjs gitignore

### DIFF
--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -471,8 +471,8 @@ jspm_packages/
 .DS_Store
 .env.local
 target/
-.next/
 .idea/
+.next/
 debug/
 .vscode/tasks.json
 build/

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -167,7 +167,7 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
 
     // ANCHOR gitignore
     extendGitignore(this)
-    extendGitignore(this, ['.next/', '.idea/', 'debug/', '.vscode/tasks.json', 'build/'])
+    extendGitignore(this, ['.next/', 'debug/', '.vscode/tasks.json', 'build/'])
 
     // ANCHOR Codemod
     this.addDevDeps('jscodeshift')


### PR DESCRIPTION
The folder is added by default in extendGitignore function and therefore does not need to be added manually.