### PR TITLE
PLa-226 Remove `import/no-relative-parent-imports` rule from the templates repo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,7 +88,7 @@
       "error"
     ],
     "import/no-relative-parent-imports": [
-      "error"
+      "off"
     ],
     "no-negated-condition": [
       "error"
@@ -187,6 +187,17 @@
       ],
       "rules": {
         "import/no-relative-parent-imports": "off"
+      }
+    },
+    {
+      "files": [
+        "./src/apollo-server/codegen-config.ts",
+        "./src/nextjs/codegen-config.ts"
+      ],
+      "rules": {
+        "eslint-comments/no-unused-disable": [
+          "off"
+        ]
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -188,17 +188,6 @@
       "rules": {
         "import/no-relative-parent-imports": "off"
       }
-    },
-    {
-      "files": [
-        "./src/apollo-server/codegen-config.ts",
-        "./src/nextjs/codegen-config.ts"
-      ],
-      "rules": {
-        "eslint-comments/no-unused-disable": [
-          "off"
-        ]
-      }
     }
   ],
   "plugins": [

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -57,12 +57,6 @@ addLinters({
   lintPaths: ['.projenrc.ts', 'src'],
   extraEslintConfigs: [
     {
-      overrides: [
-        {
-          files: ['./src/apollo-server/codegen-config.ts', './src/nextjs/codegen-config.ts'],
-          rules: {'eslint-comments/no-unused-disable': ['off']},
-        },
-      ],
       rules: {
         'import/no-relative-parent-imports': ['off'],
       },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,23 @@ project.package.addField('version', version)
 project.package.addField('overrides', {'@types/babel__traverse': 'ts3.9'})
 
 // ANCHOR ESLint and prettier setup
-addLinters({project, lintPaths: ['.projenrc.ts', 'src']})
+addLinters({
+  project,
+  lintPaths: ['.projenrc.ts', 'src'],
+  extraEslintConfigs: [
+    {
+      overrides: [
+        {
+          files: ['./src/apollo-server/codegen-config.ts', './src/nextjs/codegen-config.ts'],
+          rules: {'eslint-comments/no-unused-disable': ['off']},
+        },
+      ],
+      rules: {
+        'import/no-relative-parent-imports': ['off'],
+      },
+    },
+  ],
+})
 
 // Solves the typescript > 4 problem
 // https://github.com/projen/projen/blob/0eae60e2cb5a5f7e4b80f96d8760f4be781f82f4/src/cdk/jsii-project.ts#L343

--- a/src/apollo-server/codegen-config.ts
+++ b/src/apollo-server/codegen-config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-relative-parent-imports -- types are not bundled and therefore are not correctly exported with path aliases
 import type {CodegenConfig} from '../common/codegen/types'
 
 export const codegenConfig: CodegenConfig = {

--- a/src/apollo-server/index.ts
+++ b/src/apollo-server/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import {execSync} from 'child_process'
 import * as path from 'path'
 import * as projen from 'projen'

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import {execSync} from 'child_process'
 import * as projen from 'projen'
 import {AwsCdkTypeScriptApp, AwsCdkTypeScriptAppOptions} from 'projen/lib/awscdk'

--- a/src/common/codegen/codegen-config-yaml.ts
+++ b/src/common/codegen/codegen-config-yaml.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import type {Project, YamlFileOptions} from 'projen'
 import {YamlFile} from 'projen'
 import type {MaybePlural} from '../MaybePlural'

--- a/src/common/codegen/types/CodegenConfig.ts
+++ b/src/common/codegen/types/CodegenConfig.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import type {MaybePlural} from '../../MaybePlural'
 import type {ConfiguredOutput} from './ConfiguredOutput'
 import type {Schema} from './Schema'

--- a/src/common/codegen/types/ConfiguredOutput.ts
+++ b/src/common/codegen/types/ConfiguredOutput.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import type {MaybePlural} from '../../MaybePlural'
 import type {ConfiguredPlugin, PluginConfig} from './Plugin'
 

--- a/src/common/files/AssetFile.ts
+++ b/src/common/files/AssetFile.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import * as fs from 'fs'
 import {format} from 'prettier'
 import {Project, TextFile, TextFileOptions} from 'projen'

--- a/src/common/git/husky.ts
+++ b/src/common/git/husky.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import * as path from 'path'
 import type {NodeProject} from 'projen/lib/javascript'
 import {AssetFile} from '../files/AssetFile'

--- a/src/nextjs/codegen-config.ts
+++ b/src/nextjs/codegen-config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-relative-parent-imports -- types are not bundled and therefore are not correctly exported with path aliases
 import type {CodegenConfig} from '../common/codegen/types'
 
 export const codegenConfig: CodegenConfig = {

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import {execSync} from 'child_process'
 import * as path from 'path'
 import * as projen from 'projen'

--- a/src/nextjs/jest.ts
+++ b/src/nextjs/jest.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import * as path from 'path'
 import * as projen from 'projen'
 import type {OttofellerNextjsProject, OttofellerNextjsProjectOptions} from '.'

--- a/src/nextjs/setup-ui-packages.ts
+++ b/src/nextjs/setup-ui-packages.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- JSII project rewrites tsconfig thus always overriding introduced aliases */
 import * as path from 'path'
 import * as projen from 'projen'
 import type {OttofellerNextjsProject, OttofellerNextjsProjectOptions} from '.'


### PR DESCRIPTION
Closes pla-226.