### PR TITLE
PLA-226 Remove no-relative-parent-imports rule from job.ts

### DIFF
--- a/src/common/github/jobs/job.ts
+++ b/src/common/github/jobs/job.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-parent-imports -- types are not bundled and therefore are not correctly exported with path aliases */
 import * as projen from 'projen'
 import type {Job, JobStep} from 'projen/lib/github/workflows-model'
 import type {MaybePlural} from '../../MaybePlural'


### PR DESCRIPTION
Closes PLA-226.

The import has leaked from another PR so need to remove it here.