### PR TITLE
PLA-225 Add consistent-type-assertions rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,6 +69,12 @@
         "ts-ignore": "allow-with-description"
       }
     ],
+    "@typescript-eslint/consistent-type-assertions": [
+      "error",
+      {
+        "assertionStyle": "never"
+      }
+    ],
     "@typescript-eslint/no-duplicate-imports": [
       "error"
     ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -55,13 +55,7 @@ project.package.addField('overrides', {'@types/babel__traverse': 'ts3.9'})
 addLinters({
   project,
   lintPaths: ['.projenrc.ts', 'src'],
-  extraEslintConfigs: [
-    {
-      rules: {
-        'import/no-relative-parent-imports': ['off'],
-      },
-    },
-  ],
+  extraEslintConfigs: [{rules: {'import/no-relative-parent-imports': ['off']}}],
 })
 
 // Solves the typescript > 4 problem

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,13 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
+        "eslint": "8.42.0",
         "prettier": "2.8.0",
         "projen": "^0.71.82"
       },
       "devDependencies": {
         "@ottofeller/eslint-plugin-ottofeller": "0.1.4",
-        "@types/eslint": "^8.37.0",
+        "@types/eslint": "8.40.0",
         "@types/jest": "^27",
         "@types/jscodeshift": "^0.11.6",
         "@types/node": "^16",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@ottofeller/eslint-plugin-ottofeller": "0.1.4",
-    "@types/eslint": "^8.37.0",
+    "@types/eslint": "8.40.0",
     "@types/jest": "^27",
     "@types/jscodeshift": "^0.11.6",
     "@types/node": "^16",
@@ -64,7 +64,7 @@
     "projen": "^0.71.82"
   },
   "dependencies": {
-    "eslint": "^8.18.0",
+    "eslint": "8.42.0",
     "prettier": "2.8.0",
     "projen": "^0.71.82"
   },

--- a/src/apollo-server/__tests__/__snapshots__/index.ts.snap
+++ b/src/apollo-server/__tests__/__snapshots__/index.ts.snap
@@ -184,6 +184,12 @@ ACCESS_TOKEN=5aff40b2312321laksdkncKSDA
           "ts-ignore": "allow-with-description",
         },
       ],
+      "@typescript-eslint/consistent-type-assertions": Array [
+        "error",
+        Object {
+          "assertionStyle": "never",
+        },
+      ],
       "@typescript-eslint/no-duplicate-imports": Array [
         "error",
       ],

--- a/src/apollo-server/__tests__/index.ts
+++ b/src/apollo-server/__tests__/index.ts
@@ -93,6 +93,7 @@ describe('Apollo server template', () => {
   })
 
   test('formats ".projenrc.mjs" file after synthesis', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TS is not aware of the Jest mock, thus casting is needed
     const mockedExecSync = execSync as unknown as jest.Mock<Buffer, [string]>
     const project = new TestApolloServerProject()
     project.postSynthesize()

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -168,6 +168,12 @@ Object {
           "ts-ignore": "allow-with-description",
         },
       ],
+      "@typescript-eslint/consistent-type-assertions": Array [
+        "error",
+        Object {
+          "assertionStyle": "never",
+        },
+      ],
       "@typescript-eslint/no-duplicate-imports": Array [
         "error",
       ],

--- a/src/cdk/__tests__/index.ts
+++ b/src/cdk/__tests__/index.ts
@@ -97,6 +97,7 @@ describe('CDK template', () => {
   })
 
   test('formats ".projenrc.ts" file after synthesis', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TS is not aware of the Jest mock, thus casting is needed
     const mockedExecSync = execSync as unknown as jest.Mock<Buffer, [string]>
     const project = new TestCDKProject()
     project.postSynthesize()

--- a/src/common/files/__tests__/index.ts
+++ b/src/common/files/__tests__/index.ts
@@ -29,6 +29,7 @@ describe('AssetFile util', () => {
   })
 
   test('formats JS/TS code with prettier after template replacement', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TS is not aware of the Jest mock, thus casting is needed
     const mockedFormat = format as unknown as jest.Mock<string, [string, Options]>
     mockedFormat.mockReturnValue('formatted content')
     const project = new TestProject()

--- a/src/common/lint/configs/eslint-config-quality.ts
+++ b/src/common/lint/configs/eslint-config-quality.ts
@@ -32,6 +32,7 @@ export const eslintConfigQuality: Linter.Config = {
       'error',
       {'ts-expect-error': 'allow-with-description', 'ts-ignore': 'allow-with-description'},
     ],
+    '@typescript-eslint/consistent-type-assertions': ['error', {assertionStyle: 'never'}],
     '@typescript-eslint/no-duplicate-imports': ['error'],
     '@typescript-eslint/no-shadow': ['error'],
     '@typescript-eslint/no-unused-expressions': ['error'],

--- a/src/common/vscode-settings/vscode-settings.ts
+++ b/src/common/vscode-settings/vscode-settings.ts
@@ -14,6 +14,7 @@ export class VsCodeSettings extends JsonFile {
    * Looks for VSCode settings in the given project.
    */
   public static of(project: Project): VsCodeSettings | undefined {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Assume the file is of desired shape if exists
     return project.tryFindObjectFile(VsCodeSettings._FILENAME) as VsCodeSettings | undefined
   }
 

--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -173,6 +173,12 @@ node_modules
           "ts-ignore": "allow-with-description",
         },
       ],
+      "@typescript-eslint/consistent-type-assertions": Array [
+        "error",
+        Object {
+          "assertionStyle": "never",
+        },
+      ],
       "@typescript-eslint/no-duplicate-imports": Array [
         "error",
       ],

--- a/src/nextjs/__tests__/index.ts
+++ b/src/nextjs/__tests__/index.ts
@@ -120,6 +120,7 @@ describe('NextJS template', () => {
   })
 
   test('formats ".projenrc.ts" file after synthesis', () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TS is not aware of the Jest mock, thus casting is needed
     const mockedExecSync = execSync as unknown as jest.Mock<Buffer, [string]>
     const project = new TestNextJsTypeScriptProject()
     expect(project.postSynthFormattingPaths).toHaveLength(2)


### PR DESCRIPTION
The rule is added to the project as well as all the templates. "assertionStyle": "never" restricts the use of type assertions. Together with eslint-comments/require-description rule it makes all assertions require an explanation of why it is needed.

Closes PLA-225.