### PR TITLE
PLA-235 Add workflowNodeVersion option to PullRequestTest

### DIFF
--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -429,7 +429,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -451,7 +451,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -473,7 +473,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3
@@ -495,7 +495,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v3


### PR DESCRIPTION
Closes PLA-235.

The options is pulled from the project options. As a fallback use minNodeVersion from package.

NOTE: This changes the default behaviour: as the `minNodeVersion` is set `12.22.0` by default, the projects that do not set neither `workflowNodeVersion` nor `minNodeVersion` would have their test workflow updated to use node@12.22.0 (previously it used version `16`).