### PR TITLE
PLA-236 Switch commit message script to node.js

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.github/workflows/publish-release.yml linguist-generated
 /.github/workflows/test.yml linguist-generated
 /.gitignore linguist-generated
+/.husky/check-commit-msg.js linguist-generated
 /.husky/commit-msg linguist-generated
 /.npmignore linguist-generated
 /.npmrc linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tsconfig.json
 !/.prettierrc.json
 !/.eslintrc.json
 !/.husky/commit-msg
+!/.husky/check-commit-msg.js
 !/.github/workflows/test.yml
 !/.github/workflows/create-release.yml
 !/.github/workflows/publish-release.yml

--- a/.husky/check-commit-msg.js
+++ b/.husky/check-commit-msg.js
@@ -1,0 +1,16 @@
+const {HUSKY_DEBUG} = process.env
+
+function debug(debugMessage) {
+  if (HUSKY_DEBUG === '1') {
+    console.log(`husky (debug) - ${debugMessage}`)
+  }
+}
+
+const pattern = /^\w{2,4}-\d+\s/
+const message = process.argv[2]
+debug(`Test message "${message}" with pattern "${pattern}"`)
+
+if (!pattern.test(message)) {
+  console.error(`"${message}" - malformed commit message. Prepend the message with the task ID (e.g. pla-123).`)
+  process.exit(1)
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,8 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-head -1 $@ | grep -Eq "^\w{2,4}-\d+\s.+" || \
-{ 
-  echo "Malformed commit message. Prepend the message with the task ID (e.g. pla-123)."; \
-  exit 1;
-}
+node .husky/check-commit-msg.js "$(head -1 $@)"

--- a/src/common/git/__tests__/index.ts
+++ b/src/common/git/__tests__/index.ts
@@ -28,20 +28,28 @@ describe('extendGitignore function', () => {
 })
 
 describe('addHusky function', () => {
-  const commitMsgFileName = '.husky/commit-msg'
-  const assetFilePath = path.resolve('src/common/git/assets/commit-msg')
-  const assetFileContents = fs.readFileSync(assetFilePath, {encoding: 'utf-8'})
-  expect(assetFileContents).toBeDefined()
+  const sourceFolder = 'src/common/git/assets'
+  const destinationFolder = '.husky'
+  const shellScriptName = 'commit-msg'
+  const nodeScriptFileName = 'check-commit-msg.js'
+
+  const shellScriptSourcePath = path.join(sourceFolder, shellScriptName)
+  const shellScriptDestinationPath = path.join(destinationFolder, shellScriptName)
+  const shellScriptContents = fs.readFileSync(shellScriptSourcePath, {encoding: 'utf-8'})
+  expect(shellScriptContents).toBeDefined()
+
+  const nodeScriptSourcePath = path.join(sourceFolder, nodeScriptFileName)
+  const nodeScriptDestinationPath = path.join(destinationFolder, nodeScriptFileName)
+  const nodeScriptContents = fs.readFileSync(nodeScriptSourcePath, {encoding: 'utf-8'})
+  expect(nodeScriptContents).toBeDefined()
 
   test('sets up husky with a commit-msg hook', () => {
     const project = new TestProject()
     addHusky(project, {})
     const snapshot = synthSnapshot(project)
     expect(snapshot['package.json'].devDependencies).toHaveProperty('husky')
-
-    const commitMsgFile = snapshot[commitMsgFileName]
-    expect(commitMsgFile).toBeDefined()
-    expect(commitMsgFile).toEqual(assetFileContents)
+    expect(snapshot[shellScriptDestinationPath]).toEqual(shellScriptContents)
+    expect(snapshot[nodeScriptDestinationPath]).toEqual(nodeScriptContents)
   })
 
   test('has disabled commit-msg hook with hasDefaultCommitHook option', () => {
@@ -49,7 +57,8 @@ describe('addHusky function', () => {
     addHusky(project, {hasDefaultCommitHook: false})
     const snapshot = synthSnapshot(project)
     expect(snapshot['package.json'].devDependencies).toHaveProperty('husky')
-    expect(snapshot[commitMsgFileName]).not.toBeDefined()
+    expect(snapshot[shellScriptDestinationPath]).not.toBeDefined()
+    expect(snapshot[nodeScriptDestinationPath]).not.toBeDefined()
   })
 })
 

--- a/src/common/git/assets/check-commit-msg.js
+++ b/src/common/git/assets/check-commit-msg.js
@@ -1,0 +1,16 @@
+const {HUSKY_DEBUG} = process.env
+
+function debug(debugMessage) {
+  if (HUSKY_DEBUG === '1') {
+    console.log(`husky (debug) - ${debugMessage}`)
+  }
+}
+
+const pattern = /^\w{2,4}-\d+\s/
+const message = process.argv[2]
+debug(`Test message "${message}" with pattern "${pattern}"`)
+
+if (!pattern.test(message)) {
+  console.error(`"${message}" - malformed commit message. Prepend the message with the task ID (e.g. pla-123).`)
+  process.exit(1)
+}

--- a/src/common/git/assets/commit-msg
+++ b/src/common/git/assets/commit-msg
@@ -1,8 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-head -1 $@ | grep -Eq "^\w{2,4}-\d+\s.+" || \
-{ 
-  echo "Malformed commit message. Prepend the message with the task ID (e.g. pla-123)."; \
-  exit 1;
-}
+node .husky/check-commit-msg.js "$(head -1 $@)"

--- a/src/common/git/husky.ts
+++ b/src/common/git/husky.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import type {NodeProject} from 'projen/lib/javascript'
 import {AssetFile} from '../files/AssetFile'
-import {WithGitHooks} from './with-git-hooks'
+import type {WithGitHooks} from './with-git-hooks'
 
 export const addHusky = (project: NodeProject, options: WithGitHooks): void => {
   project.addDevDeps('husky')
@@ -11,6 +11,20 @@ export const addHusky = (project: NodeProject, options: WithGitHooks): void => {
     return
   }
 
-  const commitMsgFilePath = path.join(__dirname, '../../..', 'src/common/git/assets/commit-msg')
-  new AssetFile(project, '.husky/commit-msg', {sourcePath: commitMsgFilePath, executable: true, readonly: false})
+  const sourceFolder = path.join(__dirname, '../../..', 'src/common/git/assets')
+  const destinationFolder = '.husky'
+  const shellScriptFilename = 'commit-msg'
+  const nodeScriptFilename = 'check-commit-msg.js'
+
+  new AssetFile(project, path.join(destinationFolder, shellScriptFilename), {
+    sourcePath: path.join(sourceFolder, shellScriptFilename),
+    executable: true,
+    readonly: false,
+  })
+
+  new AssetFile(project, path.join(destinationFolder, nodeScriptFilename), {
+    sourcePath: path.join(sourceFolder, nodeScriptFilename),
+    executable: true,
+    readonly: false,
+  })
 }


### PR DESCRIPTION
Since grep implementation affects correctness of pattern matching and grep version is not controlled in projects, pattern matching part of the script needs a more stable environment and node.js is a good candidate.

The initial script includes a part sourcing `.husky/_/husky.sh` and thus it is not possible to completely move the entire script to node.js. Hence only the part with pattern matching is run in node.js, while everything else is left as is.

Closes PLA-236.