### PR TITLE
PLA-237 Extend CodegenConfigYaml

### DIFF
--- a/src/common/codegen/__tests__/index.ts
+++ b/src/common/codegen/__tests__/index.ts
@@ -1,7 +1,7 @@
 import {NodeProject, NodeProjectOptions} from 'projen/lib/javascript'
 import {synthSnapshot} from 'projen/lib/util/synth'
 import * as YAML from 'yaml'
-import {CodegenConfig, CodegenConfigYaml} from '..'
+import {CodegenConfig, CodegenConfigYaml, PluginConfig} from '..'
 
 describe('Codegen utils', () => {
   const generatedIndex = './generated/index.ts'
@@ -81,6 +81,69 @@ describe('Codegen utils', () => {
         [generatedIndex]: {
           ...config.generates[generatedIndex],
           plugins,
+        },
+      },
+    }
+
+    expect(YAML.parse(snapshot['codegen.yml'])).toStrictEqual(expectedConfig)
+  })
+
+  test('allows output config override', () => {
+    const project = new TestProject()
+    const configFile = new CodegenConfigYaml(project, config)
+    const pluginConfig: PluginConfig = {configKey: 'configValue'}
+    configFile.overrideConfigForOutput(generatedIndex, pluginConfig)
+    const snapshot = synthSnapshot(project)
+
+    const expectedConfig: CodegenConfig = {
+      ...config,
+      generates: {
+        ...config.generates,
+        [generatedIndex]: {
+          ...config.generates[generatedIndex],
+          config: pluginConfig,
+        },
+      },
+    }
+
+    expect(YAML.parse(snapshot['codegen.yml'])).toStrictEqual(expectedConfig)
+  })
+
+  test('allows output preset override', () => {
+    const project = new TestProject()
+    const configFile = new CodegenConfigYaml(project, config)
+    const preset = 'client'
+    configFile.overridePresetForOutput(generatedIndex, preset)
+    const snapshot = synthSnapshot(project)
+
+    const expectedConfig: CodegenConfig = {
+      ...config,
+      generates: {
+        ...config.generates,
+        [generatedIndex]: {
+          ...config.generates[generatedIndex],
+          preset,
+        },
+      },
+    }
+
+    expect(YAML.parse(snapshot['codegen.yml'])).toStrictEqual(expectedConfig)
+  })
+
+  test('allows output preset-config override', () => {
+    const project = new TestProject()
+    const configFile = new CodegenConfigYaml(project, config)
+    const presetConfig = {extension: '.generated.tsx', baseTypesPath: 'types.ts'}
+    configFile.overridePresetConfigForOutput(generatedIndex, presetConfig)
+    const snapshot = synthSnapshot(project)
+
+    const expectedConfig: CodegenConfig = {
+      ...config,
+      generates: {
+        ...config.generates,
+        [generatedIndex]: {
+          ...config.generates[generatedIndex],
+          presetConfig: presetConfig,
         },
       },
     }

--- a/src/common/codegen/codegen-config-yaml.ts
+++ b/src/common/codegen/codegen-config-yaml.ts
@@ -1,7 +1,7 @@
 import type {Project, YamlFileOptions} from 'projen'
 import {YamlFile} from 'projen'
 import type {MaybePlural} from '../MaybePlural'
-import type {CodegenConfig, ConfiguredPlugin, Schema} from './types'
+import type {CodegenConfig, ConfiguredPlugin, PluginConfig, Schema} from './types'
 
 /**
  * A wrapper around YamlFile. Represents a codegen config file.
@@ -56,6 +56,42 @@ export class CodegenConfigYaml {
    */
   overridePluginsForOutput(outputPath: string, plugins?: Array<string | ConfiguredPlugin>): CodegenConfigYaml {
     this.file.addOverride(`generates.${outputPath.replace(/\./g, '\\.')}.plugins`, plugins)
+    return this
+  }
+
+  /**
+   * Adds an override to the `config` property an outputPath within `generates` object.
+   * With empty value deletes the config property.
+   *
+   * @param outputPath The path to the generated file.
+   * @param config A plugin config.
+   */
+  overrideConfigForOutput(outputPath: string, config?: PluginConfig): CodegenConfigYaml {
+    this.file.addOverride(`generates.${outputPath.replace(/\./g, '\\.')}.config`, config)
+    return this
+  }
+
+  /**
+   * Adds an override to the `preset` property an outputPath within `generates` object.
+   * With empty value deletes the preset property.
+   *
+   * @param outputPath The path to the generated file.
+   * @param preset A plugin preset.
+   */
+  overridePresetForOutput(outputPath: string, preset?: string): CodegenConfigYaml {
+    this.file.addOverride(`generates.${outputPath.replace(/\./g, '\\.')}.preset`, preset)
+    return this
+  }
+
+  /**
+   * Adds an override to the `preset-config` property an outputPath within `generates` object.
+   * With empty value deletes the preset-config property.
+   *
+   * @param outputPath The path to the generated file.
+   * @param presetConfig A plugin preset config.
+   */
+  overridePresetConfigForOutput(outputPath: string, presetConfig?: {[key: string]: any}): CodegenConfigYaml {
+    this.file.addOverride(`generates.${outputPath.replace(/\./g, '\\.')}.presetConfig`, presetConfig)
     return this
   }
 }


### PR DESCRIPTION
Add methods to handle config, preset and presetConfig properties for each generated path.

Closes PLA-237.