### PR TITLE
PLA-240 Update array of files formatted post synth

### DIFF
--- a/src/nextjs/__tests__/index.ts
+++ b/src/nextjs/__tests__/index.ts
@@ -124,7 +124,11 @@ describe('NextJS template', () => {
     const mockedExecSync = execSync as unknown as jest.Mock<Buffer, [string]>
     const project = new TestNextJsTypeScriptProject()
     expect(project.postSynthFormattingPaths).toHaveLength(2)
-    const formattingPaths = project.postSynthFormattingPaths.join(' ')
+
+    const formattingPaths = project.postSynthFormattingPaths
+      .map((filePath) => `${project.outdir}/${filePath}`)
+      .join(' ')
+
     project.postSynthesize()
     expect(mockedExecSync).toBeCalledTimes(2)
     expect(mockedExecSync).toBeCalledWith(`prettier --write ${formattingPaths}`)


### PR DESCRIPTION
The formatting performed in the postSynthesize hook needs to include project outdir for subprojects (otherwise the files are searched for in the root folder).

For nested projects projenrc exists only for the root project and thus subproject have no need to format one.

Closes PLA-240.