### PR TITLE
Restore install tasks in SST template

### DIFF
--- a/src/sst/__tests__/__snapshots__/index.ts.snap
+++ b/src/sst/__tests__/__snapshots__/index.ts.snap
@@ -751,6 +751,24 @@ tsconfig.tsbuildinfo
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npm install",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "npm ci",
+          },
+        ],
+      },
       "lint": Object {
         "name": "lint",
         "steps": Array [

--- a/src/sst/index.ts
+++ b/src/sst/index.ts
@@ -62,8 +62,6 @@ export class OttofellerSSTProject extends TypeScriptAppProject {
     // ANCHOR Setup tasks
     this.removeTask('build')
     this.removeTask('compile')
-    this.removeTask('install')
-    this.removeTask('install:ci')
     this.removeTask('package')
     this.removeTask('post-compile')
     this.removeTask('pre-compile')


### PR DESCRIPTION
The tasks are used internally by NodePackage and are required for proper projen runs. Fixes an error on an attempt to install dependencies.