### PR TITLE
PLA-211 Extend padding-line rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,6 +60,17 @@
         "blankLine": "always",
         "prev": "multiline-let",
         "next": "*"
+      },
+      {
+        "blankLine": "never",
+        "prev": [
+          "singleline-const",
+          "singleline-let"
+        ],
+        "next": [
+          "singleline-const",
+          "singleline-let"
+        ]
       }
     ],
     "@typescript-eslint/ban-ts-comment": [

--- a/src/apollo-server/__tests__/__snapshots__/index.ts.snap
+++ b/src/apollo-server/__tests__/__snapshots__/index.ts.snap
@@ -275,6 +275,17 @@ ACCESS_TOKEN=5aff40b2312321laksdkncKSDA
           "next": "*",
           "prev": "multiline-let",
         },
+        Object {
+          "blankLine": "never",
+          "next": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+          "prev": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+        },
       ],
       "react-hooks/exhaustive-deps": Array [
         "error",

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -259,6 +259,17 @@ Object {
           "next": "*",
           "prev": "multiline-let",
         },
+        Object {
+          "blankLine": "never",
+          "next": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+          "prev": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+        },
       ],
       "react-hooks/exhaustive-deps": Array [
         "error",

--- a/src/common/git/__tests__/index.ts
+++ b/src/common/git/__tests__/index.ts
@@ -32,7 +32,6 @@ describe('addHusky function', () => {
   const destinationFolder = '.husky'
   const shellScriptName = 'commit-msg'
   const nodeScriptFileName = 'check-commit-msg.js'
-
   const shellScriptSourcePath = path.join(sourceFolder, shellScriptName)
   const shellScriptDestinationPath = path.join(destinationFolder, shellScriptName)
   const shellScriptContents = fs.readFileSync(shellScriptSourcePath, {encoding: 'utf-8'})

--- a/src/common/github/__tests__/index.ts
+++ b/src/common/github/__tests__/index.ts
@@ -53,7 +53,6 @@ describe('GitHub utils', () => {
       new PullRequestTest(project.github!)
       const snapshot = synthSnapshot(project)
       const workflow = YAML.parse(snapshot[testWorkflowPath])
-
       const jobs = Object.values<projen.github.workflows.Job>(workflow.jobs).map((j) => j.steps.at(-1)!.run)
       expect(jobs).toHaveLength(3)
       expect(jobs).toContain('npm run typecheck')
@@ -66,7 +65,6 @@ describe('GitHub utils', () => {
       new PullRequestTest(project.github!)
       const snapshot = synthSnapshot(project)
       const workflow = YAML.parse(snapshot[testWorkflowPath])
-
       const jobs = Object.values<projen.github.workflows.Job>(workflow.jobs).map((j) => j.steps.at(-1)!.run)
       expect(jobs).toHaveLength(3)
       expect(jobs).toContain('pnpm run typecheck')
@@ -216,7 +214,6 @@ describe('GitHub utils', () => {
       new ReleaseWorkflow(project.github!)
       const snapshot = synthSnapshot(project)
       const workflow = YAML.parse(snapshot[releaseWorkflowPath])
-
       const createJob = workflow.jobs.create
       expect(createJob).toBeDefined()
       expect(createJob.steps[0].uses).toEqual('ottofeller/github-actions/create-release@main')

--- a/src/common/github/jobs/__tests__/index.ts
+++ b/src/common/github/jobs/__tests__/index.ts
@@ -148,7 +148,6 @@ describe('GitHub utils', () => {
       const pnpmVersion = '8.6.5'
       const project = new TestProject({packageManager: NodePackageManager.PNPM, pnpmVersion})
       const setupNodeSteps = setupNode({projectPackage: project.package})
-
       const pnpmSetupStep = setupNodeSteps.find((step) => step.uses === 'pnpm/action-setup@v2')
       expect(pnpmSetupStep).toBeDefined()
       expect(pnpmSetupStep!.with!.version).toEqual(pnpmVersion)

--- a/src/common/lint/__tests__/index.ts
+++ b/src/common/lint/__tests__/index.ts
@@ -44,7 +44,6 @@ describe('addLinters function', () => {
     const project = new TestProject()
     addLinters({project, lintPaths: []})
     const snapshot = synthSnapshot(project)
-
     const eslintrc = snapshot['.eslintrc.json']
     expect(eslintrc).toBeDefined()
     const {rules} = eslintrc

--- a/src/common/lint/configs/eslint-config-formatting.ts
+++ b/src/common/lint/configs/eslint-config-formatting.ts
@@ -23,6 +23,7 @@ export const eslintConfigFormatting: Linter.Config = {
       {blankLine: 'always', prev: 'multiline-expression', next: '*'},
       {blankLine: 'always', prev: '*', next: 'multiline-let'},
       {blankLine: 'always', prev: 'multiline-let', next: '*'},
+      {blankLine: 'never', prev: ['singleline-const', 'singleline-let'], next: ['singleline-const', 'singleline-let']},
     ],
   },
 }

--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -264,6 +264,17 @@ node_modules
           "next": "*",
           "prev": "multiline-let",
         },
+        Object {
+          "blankLine": "never",
+          "next": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+          "prev": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+        },
       ],
       "react-hooks/exhaustive-deps": Array [
         "error",

--- a/src/nextjs/assets/jest.config.js
+++ b/src/nextjs/assets/jest.config.js
@@ -1,6 +1,5 @@
 const nextJest = require('next/jest')
 const defaultConfig = require('./jest.config.defaults')
-
 const createJestConfig = nextJest({dir: './'})
 
 /** @type {import('@jest/types').Config.InitialOptions} */

--- a/src/nextjs/sample-code.ts
+++ b/src/nextjs/sample-code.ts
@@ -16,7 +16,6 @@ export function sampleCode(
   }
 
   const isUiConfigEnabled = options.isUiConfigEnabled ?? true
-
   const homeComponentFilePath = 'src/Home/index.tsx'
   new projen.SampleFile(project, homeComponentFilePath, {sourcePath: path.join(assetsDir, homeComponentFilePath)})
 

--- a/src/sst/__tests__/__snapshots__/index.ts.snap
+++ b/src/sst/__tests__/__snapshots__/index.ts.snap
@@ -259,6 +259,17 @@ Object {
           "next": "*",
           "prev": "multiline-let",
         },
+        Object {
+          "blankLine": "never",
+          "next": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+          "prev": Array [
+            "singleline-const",
+            "singleline-let",
+          ],
+        },
       ],
       "react-hooks/exhaustive-deps": Array [
         "error",


### PR DESCRIPTION
Disallow empty lines between one line let and const variable declarations.

Closes PLA-211.