### PR TITLE
PLA-247 Restore readonly attributes on the husky scripts

### DIFF
--- a/src/common/git/husky/check-cargo.ts
+++ b/src/common/git/husky/check-cargo.ts
@@ -24,6 +24,5 @@ export const checkCargo = (project: NodeProject, options: CheckCargoOptions) => 
     sourcePath: path.join(sourceFolder, templateFile),
     template: {templateString, replacement: commands.join('\n')},
     executable: true,
-    readonly: false,
   })
 }

--- a/src/common/git/husky/commit-message.ts
+++ b/src/common/git/husky/commit-message.ts
@@ -11,12 +11,10 @@ export const commitMessage = (project: NodeProject) => {
     sourcePath: path.join(sourceFolder, templateFile),
     template: {templateString, replacement: 'node .husky/check-commit-msg.js "$(head -1 $@)"'},
     executable: true,
-    readonly: false,
   })
 
   new AssetFile(project, path.join(destinationFolder, nodeScriptFilename), {
     sourcePath: path.join(sourceFolder, nodeScriptFilename),
     executable: true,
-    readonly: false,
   })
 }


### PR DESCRIPTION
Otherwise with no readonly attribute file is not managed by `projen` after removal and stays in the project even when no synthesis of the file is needed.

Note that originally the readonly attribute was added to allow regular hook installation through `husky`. With the readonly attribute it is not possible, though not deems significant - all additional hooks can be added to a template instead of using husky.

Closes PLA-247.