### PR TITLE
PLA-258 Remove workingDirectory from workflow steps

### DIFF
--- a/src/common/github/jobs/__tests__/index.ts
+++ b/src/common/github/jobs/__tests__/index.ts
@@ -116,9 +116,8 @@ describe('GitHub utils', () => {
         workingDirectory,
       })
 
-      setupNodeSteps.forEach((step) => {
-        expect(step.workingDirectory).toEqual(workingDirectory)
-      })
+      const workingDirectories = setupNodeSteps.map((step) => step.workingDirectory)
+      expect(workingDirectories).toEqual([undefined, undefined, undefined, workingDirectory])
     })
 
     test('allows setting projectPackage to pnpm', () => {

--- a/src/common/github/jobs/setup-node.ts
+++ b/src/common/github/jobs/setup-node.ts
@@ -58,11 +58,10 @@ export const setupNode = ({
 
   // ANCHOR Basic setup: checkout and node
   const steps: Array<JobStep> = [
-    {uses: 'actions/checkout@v3', with: {'fetch-depth': 0, ref}, workingDirectory},
+    {uses: 'actions/checkout@v3', with: {'fetch-depth': 0, ref}},
     {
       uses: 'actions/setup-node@v3',
       with: {'node-version': nodeVersion, 'registry-url': registryUrl, scope},
-      workingDirectory,
     },
   ]
 
@@ -91,7 +90,6 @@ export const setupNode = ({
       name: 'Cache node_modules',
       uses: 'actions/cache@v3',
       with: {key: `\${{ hashFiles('${directory}/${lockFile}') }}`, path: cachePath},
-      workingDirectory,
     },
     {
       // NOTE: For PNPM we need to install deps from the store.


### PR DESCRIPTION
workingDirectory is meant for use only with run steps and causes errors in parsing workflows when applied to external action such as checkout, setup-node etc.