### PR TITLE
Remove projen tasks and replace them with npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ To get rid of projen run this command:
 ```sh
 npm run eject 
 ```
-The command removes default projen task, makes projen remove its authority from all the generated files and stop tracking changes. At this moment the project is managed as a regular repository (feel fre to edit and remove files).
+The command removes default projen task, makes projen remove its authority from all the generated files and stop tracking changes. At this moment the project is managed as a regular repository (feel free to edit and remove files).
+
+Note: all the projen tasks are run via a custom runner, so the runner is saved into the project at `scripts/run-task` and the tasks remain in the project in a tasks definition file (`.projen/tasks.json`). All the internal tasks within the templates are saved as npm scripts and thus don't need this task runner. Therefore the task runner and the tasks definition file file can be deleted. If you had any custom tasks created in your project either use this runner or make sure to convert all the tasks into npm scripts before deleting the tasks definition file and the runner.
 
 ## 🛠 Development guide
 ### Install

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run eject
 ```
 The command removes default projen task, makes projen remove its authority from all the generated files and stop tracking changes. At this moment the project is managed as a regular repository (feel free to edit and remove files).
 
-Note: all the projen tasks are run via a custom runner, so the runner is saved into the project at `scripts/run-task` and the tasks remain in the project in a tasks definition file (`.projen/tasks.json`). All the internal tasks within the templates are saved as npm scripts and thus don't need this task runner. Therefore the task runner and the tasks definition file file can be deleted. If you had any custom tasks created in your project either use this runner or make sure to convert all the tasks into npm scripts before deleting the tasks definition file and the runner.
+> All the projen tasks are run via a custom runner, so the runner is saved into the project at `scripts/run-task` and the tasks remain in the project in a tasks definition file (`.projen/tasks.json`). All the internal tasks within the templates are saved as npm scripts and thus don't need this task runner. Therefore the task runner and the tasks definition file file can be deleted. If you had any custom tasks created in your project either use this runner or make sure to convert all the tasks into npm scripts before deleting the tasks definition file and the runner.
 
 ## 🛠 Development guide
 ### Install

--- a/src/apollo-server/__tests__/__snapshots__/index.ts.snap
+++ b/src/apollo-server/__tests__/__snapshots__/index.ts.snap
@@ -704,60 +704,12 @@ tsconfig.tsbuildinfo
       "PATH": "$(npx -c "node --print process.env.PATH")",
     },
     "tasks": {
-      "build": {
-        "name": "build",
-        "steps": [
-          {
-            "exec": "node esbuild.config.js",
-          },
-        ],
-      },
-      "clobber": {
-        "condition": "git diff --exit-code > /dev/null",
-        "description": "hard resets to HEAD of origin and cleans the local repo",
-        "env": {
-          "BRANCH": "$(git branch --show-current)",
-        },
-        "name": "clobber",
-        "steps": [
-          {
-            "exec": "git checkout -b scratch",
-            "name": "save current HEAD in "scratch" branch",
-          },
-          {
-            "exec": "git checkout $BRANCH",
-          },
-          {
-            "exec": "git fetch origin",
-            "name": "fetch latest changes from origin",
-          },
-          {
-            "exec": "git reset --hard origin/$BRANCH",
-            "name": "hard reset to origin commit",
-          },
-          {
-            "exec": "git clean -fdx",
-            "name": "clean all untracked files",
-          },
-          {
-            "say": "ready to rock! (unpushed commits are under the "scratch" branch)",
-          },
-        ],
-      },
       "default": {
         "description": "Synthesize project files",
         "name": "default",
         "steps": [
           {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.mjs",
-          },
-        ],
-      },
-      "dev": {
-        "name": "dev",
-        "steps": [
-          {
-            "exec": "nodemon",
           },
         ],
       },
@@ -770,33 +722,6 @@ tsconfig.tsbuildinfo
         "steps": [
           {
             "spawn": "default",
-          },
-        ],
-      },
-      "format": {
-        "name": "format",
-        "steps": [
-          {
-            "exec": "prettier --write .projenrc.mjs src",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" .projenrc.mjs src --fix",
-          },
-        ],
-      },
-      "generate-graphql-schema": {
-        "name": "generate-graphql-schema",
-        "steps": [
-          {
-            "exec": "npx apollo schema:download",
-          },
-        ],
-      },
-      "gql-to-ts": {
-        "name": "gql-to-ts",
-        "steps": [
-          {
-            "exec": "graphql-codegen -r dotenv/config --config codegen.yml dotenv_config_path=.env.development",
           },
         ],
       },
@@ -815,52 +740,6 @@ tsconfig.tsbuildinfo
         "steps": [
           {
             "exec": "npm ci",
-          },
-        ],
-      },
-      "lint": {
-        "name": "lint",
-        "steps": [
-          {
-            "exec": "prettier --check .projenrc.mjs src",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" .projenrc.mjs src",
-          },
-        ],
-      },
-      "start": {
-        "name": "start",
-        "steps": [
-          {
-            "exec": "node build/index.js",
-          },
-        ],
-      },
-      "test": {
-        "description": "Run tests",
-        "name": "test",
-        "steps": [
-          {
-            "exec": "jest --passWithNoTests --updateSnapshot",
-            "receiveArgs": true,
-          },
-        ],
-      },
-      "test:watch": {
-        "description": "Run jest in watch mode",
-        "name": "test:watch",
-        "steps": [
-          {
-            "exec": "jest --watch",
-          },
-        ],
-      },
-      "typecheck": {
-        "name": "typecheck",
-        "steps": [
-          {
-            "exec": "tsc --noEmit --project tsconfig.dev.json",
           },
         ],
       },
@@ -1336,20 +1215,19 @@ buildSync({
     "license": "Apache-2.0",
     "name": "apollo-server",
     "scripts": {
-      "build": "npx projen build",
-      "clobber": "npx projen clobber",
+      "build": "node esbuild.config.js",
       "default": "npx projen default",
-      "dev": "npx projen dev",
+      "dev": "nodemon",
       "eject": "npx projen eject",
-      "format": "npx projen format",
-      "generate-graphql-schema": "npx projen generate-graphql-schema",
-      "gql-to-ts": "npx projen gql-to-ts",
-      "lint": "npx projen lint",
+      "format": "prettier --write .projenrc.mjs src && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" .projenrc.mjs src --fix",
+      "generate-graphql-schema": "npx apollo schema:download",
+      "gql-to-ts": "graphql-codegen -r dotenv/config --config codegen.yml dotenv_config_path=.env.development",
+      "lint": "prettier --check .projenrc.mjs src && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" .projenrc.mjs src",
       "projen": "npx projen",
-      "start": "npx projen start",
-      "test": "npx projen test",
-      "test:watch": "npx projen test:watch",
-      "typecheck": "npx projen typecheck",
+      "start": "node build/index.js",
+      "test": "jest --passWithNoTests --updateSnapshot",
+      "test:watch": "jest --watch",
+      "typecheck": "tsc --noEmit --project tsconfig.dev.json",
     },
     "type": "module",
     "version": "0.0.0",

--- a/src/apollo-server/__tests__/index.ts
+++ b/src/apollo-server/__tests__/index.ts
@@ -142,6 +142,15 @@ describe('Apollo server template', () => {
       expect(snapshot['Dockerfile']).not.toBeDefined()
     })
   })
+
+  test('contains only tasks created by projen', () => {
+    const project = new TestApolloServerProject({hasGitHooks: true})
+    const snapshot = synthSnapshot(project)
+    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci']
+    const {tasks} = snapshot['.projen/tasks.json']
+    const createdTasks = Object.keys(tasks).filter((task) => !internalTasks.includes(task))
+    expect(createdTasks).toHaveLength(0)
+  })
 })
 
 class TestApolloServerProject extends OttofellerApolloServerProject {

--- a/src/apollo-server/index.ts
+++ b/src/apollo-server/index.ts
@@ -42,13 +42,6 @@ export class OttofellerApolloServerProject extends TypeScriptAppProject {
       dependabot: (options.github ?? true) && (options.dependabot ?? true),
       dependabotOptions: {scheduleInterval: projen.github.DependabotScheduleInterval.WEEKLY},
 
-      scripts: {
-        dev: 'nodemon',
-        start: 'node build/index.js',
-        'generate-graphql-schema': 'npx apollo schema:download',
-        'gql-to-ts': 'graphql-codegen -r dotenv/config --config codegen.yml dotenv_config_path=.env.development',
-      },
-
       // In case Github is enabled remove all default stuff.
       githubOptions: {mergify: false, pullRequestLint: false},
       buildWorkflow: false,
@@ -86,9 +79,34 @@ export class OttofellerApolloServerProject extends TypeScriptAppProject {
 
     // ANCHOR Scripts
     this.package.addField('type', 'module')
-    const tasksToRemove = ['build', 'compile', 'package', 'post-compile', 'pre-compile', 'watch']
-    tasksToRemove.forEach(this.removeTask.bind(this))
-    this.addTask('build', {exec: 'node esbuild.config.js'})
+
+    this.removeTask('build')
+    this.removeTask('clobber')
+    this.removeTask('compile')
+    this.removeTask('dev')
+    this.removeTask('package')
+    this.removeTask('post-compile')
+    this.removeTask('pre-compile')
+    this.removeTask('start')
+    this.removeTask('test:update')
+    this.removeTask('test:watch')
+    this.removeTask('test')
+    this.removeTask('watch')
+
+    this.addScripts({
+      build: 'node esbuild.config.js',
+      dev: 'nodemon',
+      'generate-graphql-schema': 'npx apollo schema:download',
+      'gql-to-ts': 'graphql-codegen -r dotenv/config --config codegen.yml dotenv_config_path=.env.development',
+      start: 'node build/index.js',
+    })
+
+    if (this.jest) {
+      this.addScripts({
+        test: 'jest --passWithNoTests --updateSnapshot',
+        'test:watch': 'jest --watch',
+      })
+    }
 
     // ANCHOR Source code
     const assetsDir = path.join(__dirname, '..', '..', 'src/apollo-server/assets')

--- a/src/apollo-server/index.ts
+++ b/src/apollo-server/index.ts
@@ -80,6 +80,11 @@ export class OttofellerApolloServerProject extends TypeScriptAppProject {
     // ANCHOR Scripts
     this.package.addField('type', 'module')
 
+    /*
+     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * and no need to keep the projen task runner within an ejected project.
+     */
     this.removeTask('build')
     this.removeTask('clobber')
     this.removeTask('compile')

--- a/src/apollo-server/index.ts
+++ b/src/apollo-server/index.ts
@@ -81,8 +81,8 @@ export class OttofellerApolloServerProject extends TypeScriptAppProject {
     this.package.addField('type', 'module')
 
     /*
-     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
-     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * This way we ensure smooth ejection experience with all the commands visible in package.json
      * and no need to keep the projen task runner within an ejected project.
      */
     this.removeTask('build')
@@ -171,7 +171,7 @@ export class OttofellerApolloServerProject extends TypeScriptAppProject {
 
   postSynthesize(): void {
     /*
-     * NOTE: The `.projenrc.ts` file is created by projen and its formatting is not controlled.
+     * The `.projenrc.ts` file is created by projen and its formatting is not controlled.
      * Therefore an additional formatting step is required after project initialization.
      */
     execSync('prettier --write .projenrc.mjs')

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -632,105 +632,12 @@ cdk.out/
       "PATH": "$(npx -c "node --print process.env.PATH")",
     },
     "tasks": {
-      "build": {
-        "description": "Full release build",
-        "name": "build",
-        "steps": [
-          {
-            "spawn": "default",
-          },
-          {
-            "spawn": "pre-compile",
-          },
-          {
-            "spawn": "compile",
-          },
-          {
-            "spawn": "post-compile",
-          },
-          {
-            "spawn": "test",
-          },
-          {
-            "spawn": "package",
-          },
-        ],
-      },
-      "bundle": {
-        "description": "Prepare assets",
-        "name": "bundle",
-      },
-      "clobber": {
-        "condition": "git diff --exit-code > /dev/null",
-        "description": "hard resets to HEAD of origin and cleans the local repo",
-        "env": {
-          "BRANCH": "$(git branch --show-current)",
-        },
-        "name": "clobber",
-        "steps": [
-          {
-            "exec": "git checkout -b scratch",
-            "name": "save current HEAD in "scratch" branch",
-          },
-          {
-            "exec": "git checkout $BRANCH",
-          },
-          {
-            "exec": "git fetch origin",
-            "name": "fetch latest changes from origin",
-          },
-          {
-            "exec": "git reset --hard origin/$BRANCH",
-            "name": "hard reset to origin commit",
-          },
-          {
-            "exec": "git clean -fdx",
-            "name": "clean all untracked files",
-          },
-          {
-            "say": "ready to rock! (unpushed commits are under the "scratch" branch)",
-          },
-        ],
-      },
-      "compile": {
-        "description": "Only compile",
-        "name": "compile",
-      },
       "default": {
         "description": "Synthesize project files",
         "name": "default",
         "steps": [
           {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
-          },
-        ],
-      },
-      "deploy": {
-        "description": "Deploys your CDK app to the AWS cloud",
-        "name": "deploy",
-        "steps": [
-          {
-            "exec": "cdk deploy",
-            "receiveArgs": true,
-          },
-        ],
-      },
-      "destroy": {
-        "description": "Destroys your cdk app in the AWS cloud",
-        "name": "destroy",
-        "steps": [
-          {
-            "exec": "cdk destroy",
-            "receiveArgs": true,
-          },
-        ],
-      },
-      "diff": {
-        "description": "Diffs the currently deployed app against your code",
-        "name": "diff",
-        "steps": [
-          {
-            "exec": "cdk diff",
           },
         ],
       },
@@ -743,17 +650,6 @@ cdk.out/
         "steps": [
           {
             "spawn": "default",
-          },
-        ],
-      },
-      "format": {
-        "name": "format",
-        "steps": [
-          {
-            "exec": "prettier --write .projenrc.ts src",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts src --fix",
           },
         ],
       },
@@ -772,76 +668,6 @@ cdk.out/
         "steps": [
           {
             "exec": "npm ci",
-          },
-        ],
-      },
-      "lint": {
-        "name": "lint",
-        "steps": [
-          {
-            "exec": "prettier --check .projenrc.ts src",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts src",
-          },
-        ],
-      },
-      "package": {
-        "description": "Creates the distribution package",
-        "name": "package",
-      },
-      "post-compile": {
-        "description": "Runs after successful compilation",
-        "name": "post-compile",
-        "steps": [
-          {
-            "spawn": "synth:silent",
-          },
-        ],
-      },
-      "pre-compile": {
-        "description": "Prepare the project for compilation",
-        "name": "pre-compile",
-      },
-      "synth": {
-        "description": "Synthesizes your cdk app into cdk.out",
-        "name": "synth",
-        "steps": [
-          {
-            "exec": "cdk synth",
-          },
-        ],
-      },
-      "synth:silent": {
-        "description": "Synthesizes your cdk app into cdk.out and suppresses the template in stdout (part of "yarn build")",
-        "name": "synth:silent",
-        "steps": [
-          {
-            "exec": "cdk synth -q",
-          },
-        ],
-      },
-      "test": {
-        "description": "Run tests",
-        "name": "test",
-      },
-      "typecheck": {
-        "name": "typecheck",
-        "steps": [
-          {
-            "exec": "tsc --noEmit --project tsconfig.dev.json",
-          },
-        ],
-      },
-      "watch": {
-        "description": "Watches changes in your source code and rebuilds and deploys to the current account",
-        "name": "watch",
-        "steps": [
-          {
-            "exec": "cdk deploy --hotswap",
-          },
-          {
-            "exec": "cdk watch",
           },
         ],
       },
@@ -1194,26 +1020,19 @@ cdk.out/
     "license": "Apache-2.0",
     "name": "cdk",
     "scripts": {
-      "build": "npx projen build",
-      "bundle": "npx projen bundle",
-      "clobber": "npx projen clobber",
-      "compile": "npx projen compile",
+      "build": "npm run default npm run synth:silent",
       "default": "npx projen default",
-      "deploy": "npx projen deploy",
-      "destroy": "npx projen destroy",
-      "diff": "npx projen diff",
+      "deploy": "cdk deploy",
+      "destroy": "cdk destroy",
+      "diff": "cdk diff",
       "eject": "npx projen eject",
-      "format": "npx projen format",
-      "lint": "npx projen lint",
-      "package": "npx projen package",
-      "post-compile": "npx projen post-compile",
-      "pre-compile": "npx projen pre-compile",
+      "format": "prettier --write .projenrc.ts src && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts src --fix",
+      "lint": "prettier --check .projenrc.ts src && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts src",
       "projen": "npx projen",
-      "synth": "npx projen synth",
-      "synth:silent": "npx projen synth:silent",
-      "test": "npx projen test",
-      "typecheck": "npx projen typecheck",
-      "watch": "npx projen watch",
+      "synth": "cdk synth",
+      "synth:silent": "cdk synth -q",
+      "typecheck": "tsc --noEmit --project tsconfig.dev.json",
+      "watch": "cdk deploy --hotswap && cdk watch",
     },
     "version": "0.0.0",
   },

--- a/src/cdk/__tests__/index.ts
+++ b/src/cdk/__tests__/index.ts
@@ -105,6 +105,15 @@ describe('CDK template', () => {
     expect(mockedExecSync).toBeCalledWith('prettier --write .projenrc.ts')
     expect(mockedExecSync).toBeCalledWith('eslint --fix .projenrc.ts')
   })
+
+  test('contains only tasks created by projen', () => {
+    const project = new TestCDKProject({hasGitHooks: true})
+    const snapshot = synthSnapshot(project)
+    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci']
+    const {tasks} = snapshot['.projen/tasks.json']
+    const createdTasks = Object.keys(tasks).filter((task) => !internalTasks.includes(task))
+    expect(createdTasks).toHaveLength(0)
+  })
 })
 
 class TestCDKProject extends OttofellerCDKProject {

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -61,6 +61,33 @@ export class OttofellerCDKProject extends AwsCdkTypeScriptApp {
     // ANCHOR Install dependencies
     this.addDeps('cdk-nag@2')
 
+    // ANCHOR Clean out the tasks and replace the necessary ones with npm scripts
+    // NOTE For dependent tasks the order of deletion matters, so be cautious.
+    this.removeTask('build')
+    this.removeTask('bundle')
+    this.removeTask('clobber')
+    this.removeTask('compile')
+    this.removeTask('deploy')
+    this.removeTask('destroy')
+    this.removeTask('diff')
+    this.removeTask('package')
+    this.removeTask('post-compile')
+    this.removeTask('pre-compile')
+    this.removeTask('synth')
+    this.removeTask('synth:silent')
+    this.removeTask('test')
+    this.removeTask('watch')
+
+    this.addScripts({
+      build: `${this.ejected ? '' : 'npm run default '}npm run synth:silent`,
+      deploy: 'cdk deploy',
+      destroy: 'cdk destroy',
+      diff: 'cdk diff',
+      synth: 'cdk synth',
+      'synth:silent': 'cdk synth -q',
+      watch: 'cdk deploy --hotswap && cdk watch',
+    })
+
     // ANCHOR Setup git hooks with Husky
     if (options.hasGitHooks ?? false) {
       addHusky(this, options)

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -62,8 +62,8 @@ export class OttofellerCDKProject extends AwsCdkTypeScriptApp {
     this.addDeps('cdk-nag@2')
 
     /*
-     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
-     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * This way we ensure smooth ejection experience with all the commands visible in package.json
      * and no need to keep the projen task runner within an ejected project.
      */
     // NOTE For dependent tasks the order of deletion matters, so be cautious.
@@ -118,7 +118,7 @@ export class OttofellerCDKProject extends AwsCdkTypeScriptApp {
 
   postSynthesize(): void {
     /*
-     * NOTE: The `.projenrc.ts` file is created by projen and its formatting is not controlled.
+     * The `.projenrc.ts` file is created by projen and its formatting is not controlled.
      * Therefore an additional formatting step is required after project initialization.
      */
     execSync('prettier --write .projenrc.ts')

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -61,7 +61,11 @@ export class OttofellerCDKProject extends AwsCdkTypeScriptApp {
     // ANCHOR Install dependencies
     this.addDeps('cdk-nag@2')
 
-    // ANCHOR Clean out the tasks and replace the necessary ones with npm scripts
+    /*
+     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * and no need to keep the projen task runner within an ejected project.
+     */
     // NOTE For dependent tasks the order of deletion matters, so be cautious.
     this.removeTask('build')
     this.removeTask('bundle')

--- a/src/common/git/husky/add-husky.ts
+++ b/src/common/git/husky/add-husky.ts
@@ -16,7 +16,7 @@ fi
 
 export const addHusky = (project: NodeProject, options: WithGitHooks): void => {
   project.addDevDeps('husky')
-  project.addTask('prepare', {exec: 'husky install'})
+  project.addScripts({prepare: 'husky install'})
   const {commitMsg, checkCargo, huskyCustomRules: huskyCustomRule} = options.huskyRules ?? {commitMsg: true}
   const commitMessageCommands: Array<string> = []
   const preCommitCommands: Array<string> = []

--- a/src/common/lint/add-linters.ts
+++ b/src/common/lint/add-linters.ts
@@ -43,14 +43,10 @@ export const addLinters = (props: AddLintersProps): void => {
   const includeOption = projenrcFile ? `--ignore-pattern "!${projenrcFile}" ` : ''
   const eslintRunCommand = `eslint --ext .js,.jsx,.ts,.tsx ${includeOption}${filteredPaths}`
 
-  project.addTask('typecheck', {exec: 'tsc --noEmit --project tsconfig.dev.json'})
-
-  project.addTask('format', {
-    steps: [{exec: `prettier --write ${filteredPaths}`}, {exec: `${eslintRunCommand} --fix`}],
-  })
-
-  project.addTask('lint', {
-    steps: [{exec: `prettier --check ${filteredPaths}`}, {exec: eslintRunCommand}],
+  project.addScripts({
+    typecheck: 'tsc --noEmit --project tsconfig.dev.json',
+    format: `prettier --write ${filteredPaths} && ${eslintRunCommand} --fix`,
+    lint: `prettier --check ${filteredPaths} && ${eslintRunCommand}`,
   })
 
   // ANCHOR Prettier config

--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -798,89 +798,12 @@ tsconfig.tsbuildinfo
       "PATH": "$(npx -c "node --print process.env.PATH")",
     },
     "tasks": {
-      "build": {
-        "description": "Full release build",
-        "name": "build",
-        "steps": [
-          {
-            "spawn": "default",
-          },
-          {
-            "spawn": "pre-compile",
-          },
-          {
-            "spawn": "compile",
-          },
-          {
-            "spawn": "post-compile",
-          },
-          {
-            "spawn": "test",
-          },
-          {
-            "spawn": "package",
-          },
-        ],
-      },
-      "clobber": {
-        "condition": "git diff --exit-code > /dev/null",
-        "description": "hard resets to HEAD of origin and cleans the local repo",
-        "env": {
-          "BRANCH": "$(git branch --show-current)",
-        },
-        "name": "clobber",
-        "steps": [
-          {
-            "exec": "git checkout -b scratch",
-            "name": "save current HEAD in "scratch" branch",
-          },
-          {
-            "exec": "git checkout $BRANCH",
-          },
-          {
-            "exec": "git fetch origin",
-            "name": "fetch latest changes from origin",
-          },
-          {
-            "exec": "git reset --hard origin/$BRANCH",
-            "name": "hard reset to origin commit",
-          },
-          {
-            "exec": "git clean -fdx",
-            "name": "clean all untracked files",
-          },
-          {
-            "say": "ready to rock! (unpushed commits are under the "scratch" branch)",
-          },
-        ],
-      },
-      "compile": {
-        "description": "Only compile",
-        "name": "compile",
-        "steps": [
-          {
-            "exec": "tsc --build",
-          },
-          {
-            "exec": "next build",
-          },
-        ],
-      },
       "default": {
         "description": "Synthesize project files",
         "name": "default",
         "steps": [
           {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
-          },
-        ],
-      },
-      "dev": {
-        "description": "Starts the Next.js application in development mode",
-        "name": "dev",
-        "steps": [
-          {
-            "exec": "next dev",
           },
         ],
       },
@@ -893,42 +816,6 @@ tsconfig.tsbuildinfo
         "steps": [
           {
             "spawn": "default",
-          },
-        ],
-      },
-      "export": {
-        "description": "Exports the application for production deployment",
-        "name": "export",
-        "steps": [
-          {
-            "exec": "next export",
-          },
-        ],
-      },
-      "format": {
-        "name": "format",
-        "steps": [
-          {
-            "exec": "prettier --write .projenrc.ts app src",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts app src --fix",
-          },
-        ],
-      },
-      "generate-graphql-schema": {
-        "name": "generate-graphql-schema",
-        "steps": [
-          {
-            "exec": "npx apollo schema:download",
-          },
-        ],
-      },
-      "gql-to-ts": {
-        "name": "gql-to-ts",
-        "steps": [
-          {
-            "exec": "graphql-codegen -r dotenv/config --config codegen.ts",
           },
         ],
       },
@@ -947,81 +834,6 @@ tsconfig.tsbuildinfo
         "steps": [
           {
             "exec": "npm ci",
-          },
-        ],
-      },
-      "lint": {
-        "name": "lint",
-        "steps": [
-          {
-            "exec": "prettier --check .projenrc.ts app src",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts app src",
-          },
-        ],
-      },
-      "package": {
-        "description": "Creates the distribution package",
-        "name": "package",
-      },
-      "post-compile": {
-        "description": "Runs after successful compilation",
-        "name": "post-compile",
-      },
-      "pre-compile": {
-        "description": "Prepare the project for compilation",
-        "name": "pre-compile",
-      },
-      "start": {
-        "description": "Starts the Next.js application in production mode",
-        "name": "start",
-        "steps": [
-          {
-            "exec": "next start",
-          },
-        ],
-      },
-      "telemetry": {
-        "description": "Checks the status of Next.js telemetry collection",
-        "name": "telemetry",
-        "steps": [
-          {
-            "exec": "next telemetry",
-          },
-        ],
-      },
-      "test": {
-        "description": "Run tests",
-        "name": "test",
-        "steps": [
-          {
-            "exec": "jest --no-cache --all",
-          },
-        ],
-      },
-      "test-unit:watch": {
-        "name": "test-unit:watch",
-        "steps": [
-          {
-            "exec": "jest --watch",
-          },
-        ],
-      },
-      "typecheck": {
-        "name": "typecheck",
-        "steps": [
-          {
-            "exec": "tsc --noEmit --project tsconfig.dev.json",
-          },
-        ],
-      },
-      "watch": {
-        "description": "Watch & compile in the background",
-        "name": "watch",
-        "steps": [
-          {
-            "exec": "tsc --build -w",
           },
         ],
       },
@@ -1557,28 +1369,24 @@ module.exports = {
     "license": "Apache-2.0",
     "name": "nextjs",
     "scripts": {
-      "build": "npx projen build",
-      "clobber": "npx projen clobber",
+      "build": "default && compile && test",
       "codemod:add-src-to-imports": "jscodeshift -t ./node_modules/@ottofeller/templates/lib/nextjs/add-src-reference-codemode.js --extensions=js,jsx,ts,tsx src pages",
-      "compile": "npx projen compile",
+      "compile": "tsc --build && next build",
       "default": "npx projen default",
-      "dev": "npx projen dev",
+      "dev": "next dev",
       "eject": "npx projen eject",
-      "export": "npx projen export",
-      "format": "npx projen format",
-      "generate-graphql-schema": "npx projen generate-graphql-schema",
-      "gql-to-ts": "npx projen gql-to-ts",
-      "lint": "npx projen lint",
-      "package": "npx projen package",
-      "post-compile": "npx projen post-compile",
-      "pre-compile": "npx projen pre-compile",
+      "export": "next export",
+      "format": "prettier --write .projenrc.ts app src && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts app src --fix",
+      "generate-graphql-schema": "npx apollo schema:download",
+      "gql-to-ts": "graphql-codegen -r dotenv/config --config codegen.ts",
+      "lint": "prettier --check .projenrc.ts app src && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts app src",
       "projen": "npx projen",
-      "start": "npx projen start",
-      "telemetry": "npx projen telemetry",
-      "test": "npx projen test",
-      "test-unit:watch": "npx projen test-unit:watch",
-      "typecheck": "npx projen typecheck",
-      "watch": "npx projen watch",
+      "start": "next start",
+      "telemetry": "next telemetry",
+      "test": "jest --no-cache --all",
+      "test-unit:watch": "jest --watch",
+      "typecheck": "tsc --noEmit --project tsconfig.dev.json",
+      "watch": "tsc --build -w",
     },
     "version": "0.0.0",
   },

--- a/src/nextjs/__tests__/index.ts
+++ b/src/nextjs/__tests__/index.ts
@@ -156,8 +156,7 @@ describe('NextJS template', () => {
       expect(snapshot['package.json'].devDependencies).toHaveProperty('jest-environment-jsdom')
       expect(snapshot['package.json'].devDependencies).toHaveProperty('@testing-library/react')
       expect(snapshot['package.json'].scripts).toHaveProperty('test')
-      expect(snapshot['.projen/tasks.json'].tasks.test.steps).toHaveLength(1)
-      expect(snapshot['.projen/tasks.json'].tasks.test.steps[0].exec).toEqual('jest --no-cache --all')
+      expect(snapshot['package.json'].scripts.test).toEqual('jest --no-cache --all')
       expect(snapshot['package.json'].scripts).toHaveProperty('test-unit:watch')
       expect(snapshot['jest.config.defaults.js']).toBeDefined()
       expect(snapshot['jest.config.js']).toBeDefined()
@@ -221,8 +220,17 @@ describe('NextJS template', () => {
   test('has "start" task instead of "server"', () => {
     const project = new TestNextJsTypeScriptProject()
     const snapshot = synthSnapshot(project)
-    expect(snapshot['.projen/tasks.json'].tasks).not.toHaveProperty('server')
-    expect(snapshot['.projen/tasks.json'].tasks).toHaveProperty('start')
+    expect(snapshot['package.json'].scripts).not.toHaveProperty('server')
+    expect(snapshot['package.json'].scripts).toHaveProperty('start')
+  })
+
+  test('contains only tasks created by projen', () => {
+    const project = new TestNextJsTypeScriptProject({hasGitHooks: true})
+    const snapshot = synthSnapshot(project)
+    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci']
+    const {tasks} = snapshot['.projen/tasks.json']
+    const createdTasks = Object.keys(tasks).filter((task) => !internalTasks.includes(task))
+    expect(createdTasks).toHaveLength(0)
   })
 })
 

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -94,7 +94,11 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
     this.tsconfig?.file.addOverride('compilerOptions.plugins', [{name: 'next'}])
     this.tsconfigDev?.file.addOverride('compilerOptions.plugins', [{name: 'next'}])
 
-    // ANCHOR Move all tasks into simple npm scripts
+    /*
+     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * and no need to keep the projen task runner within an ejected project.
+     */
     const scripts = {
       build: `${this.ejected ? '' : 'default && '}compile && test`,
       compile: 'tsc --build && next build',

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -95,8 +95,8 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
     this.tsconfigDev?.file.addOverride('compilerOptions.plugins', [{name: 'next'}])
 
     /*
-     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
-     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * This way we ensure smooth ejection experience with all the commands visible in package.json
      * and no need to keep the projen task runner within an ejected project.
      */
     const scripts = {
@@ -229,7 +229,7 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject {
 
   postSynthesize(): void {
     /*
-     * NOTE: The `.projenrc.ts` file is created by projen and its formatting is not controlled.
+     * The `.projenrc.ts` file is created by projen and its formatting is not controlled.
      * Therefore an additional formatting step is required after project initialization.
      *
      * The pages/_app.tsx file has optional content which is easier to format after the synthesis,

--- a/src/nextjs/jest.ts
+++ b/src/nextjs/jest.ts
@@ -25,14 +25,11 @@ export function setupJest(
   new projen.SampleFile(project, 'jest.config.js', {sourcePath: path.join(assetsDir, 'jest.config.js')})
 
   // ANCHOR Tasks
-  const testTask = project.tasks.tryFind('test')
-  const testCommand = 'jest --no-cache --all'
+  const testTask = project.removeTask('test')
+  const testTaskName = testTask ? 'test' : 'test-unit'
 
-  if (testTask) {
-    testTask.reset(testCommand)
-  } else {
-    project.addTask('test-unit', {exec: testCommand})
-  }
-
-  project.addTask('test-unit:watch', {exec: 'jest --watch'})
+  project.addScripts({
+    [testTaskName]: 'jest --no-cache --all',
+    'test-unit:watch': 'jest --watch',
+  })
 }

--- a/src/playwright/__tests__/index.ts
+++ b/src/playwright/__tests__/index.ts
@@ -1,0 +1,23 @@
+import {synthSnapshot} from 'projen/lib/util/synth'
+import {OttofellerPlaywrightProject, OttofellerPlaywrightProjectOptions} from '..'
+
+describe('Playwright template', () => {
+  test('contains only tasks created by projen', () => {
+    const project = new TestPlaywrightProject({hasGitHooks: true})
+    const snapshot = synthSnapshot(project)
+    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci']
+    const {tasks} = snapshot['.projen/tasks.json']
+    const createdTasks = Object.keys(tasks).filter((task) => !internalTasks.includes(task))
+    expect(createdTasks).toHaveLength(0)
+  })
+})
+
+class TestPlaywrightProject extends OttofellerPlaywrightProject {
+  constructor(options: Partial<OttofellerPlaywrightProjectOptions> = {}) {
+    super({
+      ...options,
+      name: 'test-playwright-project',
+      defaultReleaseBranch: 'main',
+    })
+  }
+}

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -73,6 +73,11 @@ export class OttofellerPlaywrightProject extends TypeScriptProject {
     this.package.file.addDeletionOverride('main')
     this.package.file.addDeletionOverride('types')
 
+    /*
+     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * and no need to keep the projen task runner within an ejected project.
+     */
     const tasksToRemove = [
       'build',
       'bump',

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -74,8 +74,8 @@ export class OttofellerPlaywrightProject extends TypeScriptProject {
     this.package.file.addDeletionOverride('types')
 
     /*
-     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
-     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * This way we ensure smooth ejection experience with all the commands visible in package.json
      * and no need to keep the projen task runner within an ejected project.
      */
     const tasksToRemove = [

--- a/src/sst/__tests__/__snapshots__/index.ts.snap
+++ b/src/sst/__tests__/__snapshots__/index.ts.snap
@@ -614,76 +614,12 @@ tsconfig.tsbuildinfo
       "PATH": "$(npx -c "node --print process.env.PATH")",
     },
     "tasks": {
-      "build": {
-        "name": "build",
-        "steps": [
-          {
-            "exec": "sst build",
-          },
-        ],
-      },
-      "clobber": {
-        "condition": "git diff --exit-code > /dev/null",
-        "description": "hard resets to HEAD of origin and cleans the local repo",
-        "env": {
-          "BRANCH": "$(git branch --show-current)",
-        },
-        "name": "clobber",
-        "steps": [
-          {
-            "exec": "git checkout -b scratch",
-            "name": "save current HEAD in "scratch" branch",
-          },
-          {
-            "exec": "git checkout $BRANCH",
-          },
-          {
-            "exec": "git fetch origin",
-            "name": "fetch latest changes from origin",
-          },
-          {
-            "exec": "git reset --hard origin/$BRANCH",
-            "name": "hard reset to origin commit",
-          },
-          {
-            "exec": "git clean -fdx",
-            "name": "clean all untracked files",
-          },
-          {
-            "say": "ready to rock! (unpushed commits are under the "scratch" branch)",
-          },
-        ],
-      },
-      "console": {
-        "name": "console",
-        "steps": [
-          {
-            "exec": "sst console",
-          },
-        ],
-      },
       "default": {
         "description": "Synthesize project files",
         "name": "default",
         "steps": [
           {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
-          },
-        ],
-      },
-      "deploy": {
-        "name": "deploy",
-        "steps": [
-          {
-            "exec": "sst deploy",
-          },
-        ],
-      },
-      "dev": {
-        "name": "dev",
-        "steps": [
-          {
-            "exec": "sst dev",
           },
         ],
       },
@@ -696,17 +632,6 @@ tsconfig.tsbuildinfo
         "steps": [
           {
             "spawn": "default",
-          },
-        ],
-      },
-      "format": {
-        "name": "format",
-        "steps": [
-          {
-            "exec": "prettier --write .projenrc.ts stacks sst.config.ts",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts stacks sst.config.ts --fix",
           },
         ],
       },
@@ -725,37 +650,6 @@ tsconfig.tsbuildinfo
         "steps": [
           {
             "exec": "npm ci",
-          },
-        ],
-      },
-      "lint": {
-        "name": "lint",
-        "steps": [
-          {
-            "exec": "prettier --check .projenrc.ts stacks sst.config.ts",
-          },
-          {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts stacks sst.config.ts",
-          },
-        ],
-      },
-      "remove": {
-        "name": "remove",
-        "steps": [
-          {
-            "exec": "sst remove",
-          },
-        ],
-      },
-      "test": {
-        "description": "Run tests",
-        "name": "test",
-      },
-      "typecheck": {
-        "name": "typecheck",
-        "steps": [
-          {
-            "exec": "tsc --noEmit --project tsconfig.dev.json",
           },
         ],
       },
@@ -1082,19 +976,17 @@ tsconfig.tsbuildinfo
     "license": "Apache-2.0",
     "name": "sst",
     "scripts": {
-      "build": "npx projen build",
-      "clobber": "npx projen clobber",
-      "console": "npx projen console",
+      "build": "sst build",
+      "console": "sst console",
       "default": "npx projen default",
-      "deploy": "npx projen deploy",
-      "dev": "npx projen dev",
+      "deploy": "sst deploy",
+      "dev": "sst dev",
       "eject": "npx projen eject",
-      "format": "npx projen format",
-      "lint": "npx projen lint",
+      "format": "prettier --write .projenrc.ts stacks sst.config.ts && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts stacks sst.config.ts --fix",
+      "lint": "prettier --check .projenrc.ts stacks sst.config.ts && eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts stacks sst.config.ts",
       "projen": "npx projen",
-      "remove": "npx projen remove",
-      "test": "npx projen test",
-      "typecheck": "npx projen typecheck",
+      "remove": "sst remove",
+      "typecheck": "tsc --noEmit --project tsconfig.dev.json",
     },
     "version": "0.0.0",
   },

--- a/src/sst/__tests__/index.ts
+++ b/src/sst/__tests__/index.ts
@@ -94,6 +94,15 @@ describe('SST template', () => {
     expect(mockedExecSync).toBeCalledWith('prettier --write .projenrc.ts')
     expect(mockedExecSync).toBeCalledWith('eslint --fix .projenrc.ts')
   })
+
+  test('contains only tasks created by projen', () => {
+    const project = new TestSSTProject({hasGitHooks: true})
+    const snapshot = synthSnapshot(project)
+    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci']
+    const {tasks} = snapshot['.projen/tasks.json']
+    const createdTasks = Object.keys(tasks).filter((task) => !internalTasks.includes(task))
+    expect(createdTasks).toHaveLength(0)
+  })
 })
 
 class TestSSTProject extends OttofellerSSTProject {

--- a/src/sst/index.ts
+++ b/src/sst/index.ts
@@ -60,8 +60,8 @@ export class OttofellerSSTProject extends TypeScriptAppProject {
     this.addDevDeps('sst', 'aws-cdk-lib', 'constructs')
 
     /*
-     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
-     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * This way we ensure smooth ejection experience with all the commands visible in package.json
      * and no need to keep the projen task runner within an ejected project.
      */
     this.removeTask('build')
@@ -113,7 +113,7 @@ export class OttofellerSSTProject extends TypeScriptAppProject {
 
   postSynthesize(): void {
     /*
-     * NOTE: The `.projenrc.ts` file is created by projen and its formatting is not controlled.
+     * The `.projenrc.ts` file is created by projen and its formatting is not controlled.
      * Therefore an additional formatting step is required after project initialization.
      */
     execSync('prettier --write .projenrc.ts')

--- a/src/sst/index.ts
+++ b/src/sst/index.ts
@@ -59,7 +59,11 @@ export class OttofellerSSTProject extends TypeScriptAppProject {
     // ANCHOR Install dependencies
     this.addDevDeps('sst', 'aws-cdk-lib', 'constructs')
 
-    // ANCHOR Setup tasks
+    /*
+     * ANCHOR Clean off the projen tasks and if needed replace them with regular npm scripts.
+     * NOTE This way we ensure smooth ejection experience with all the commands visible in package.json
+     * and no need to keep the projen task runner within an ejected project.
+     */
     this.removeTask('build')
     this.removeTask('clobber')
     this.removeTask('compile')

--- a/src/sst/index.ts
+++ b/src/sst/index.ts
@@ -61,16 +61,21 @@ export class OttofellerSSTProject extends TypeScriptAppProject {
 
     // ANCHOR Setup tasks
     this.removeTask('build')
+    this.removeTask('clobber')
     this.removeTask('compile')
     this.removeTask('package')
     this.removeTask('post-compile')
     this.removeTask('pre-compile')
+    this.removeTask('test')
     this.removeTask('watch')
-    this.addTask('dev', {exec: 'sst dev'})
-    this.addTask('build', {exec: 'sst build'})
-    this.addTask('deploy', {exec: 'sst deploy'})
-    this.addTask('remove', {exec: 'sst remove'})
-    this.addTask('console', {exec: 'sst console'})
+
+    this.addScripts({
+      dev: 'sst dev',
+      build: 'sst build',
+      deploy: 'sst deploy',
+      remove: 'sst remove',
+      console: 'sst console',
+    })
 
     // ANCHOR Setup git hooks with Husky
     if (options.hasGitHooks ?? false) {


### PR DESCRIPTION
Running command through projen task runner made ejection process quite heavy for a developer. Thus we move all our commands into package.json and run them as simple npm scripts. The remaining tasks are needed only for projen runs and can be easily deleted after ejection without hurting project functionality.

Closes PLA-265.