### PR TITLE
Restore bundle task for cdk template

### DIFF
--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -633,6 +633,10 @@ cdk.out/
       "PATH": "$(npx -c "node --print process.env.PATH")",
     },
     "tasks": {
+      "bundle": {
+        "description": "Prepare assets",
+        "name": "bundle",
+      },
       "default": {
         "description": "Synthesize project files",
         "name": "default",
@@ -1022,6 +1026,7 @@ cdk.out/
     "name": "cdk",
     "scripts": {
       "build": "npm run default npm run synth:silent",
+      "bundle": "npx projen bundle",
       "default": "npx projen default",
       "deploy": "cdk deploy",
       "destroy": "cdk destroy",

--- a/src/cdk/__tests__/index.ts
+++ b/src/cdk/__tests__/index.ts
@@ -109,7 +109,7 @@ describe('CDK template', () => {
   test('contains only tasks created by projen', () => {
     const project = new TestCDKProject({hasGitHooks: true})
     const snapshot = synthSnapshot(project)
-    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci']
+    const internalTasks = ['default', 'eject', 'projen', 'install', 'install:ci', 'bundle']
     const {tasks} = snapshot['.projen/tasks.json']
     const createdTasks = Object.keys(tasks).filter((task) => !internalTasks.includes(task))
     expect(createdTasks).toHaveLength(0)

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -68,7 +68,6 @@ export class OttofellerCDKProject extends AwsCdkTypeScriptApp {
      */
     // NOTE For dependent tasks the order of deletion matters, so be cautious.
     this.removeTask('build')
-    this.removeTask('bundle')
     this.removeTask('clobber')
     this.removeTask('compile')
     this.removeTask('deploy')


### PR DESCRIPTION
Without the tasks cdk fails on synth command and having the command as a npm script is not enought - a projen task is needed.

Closes PLA-268.