### PR TITLE
Move env file into sample code

### DIFF
--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -59,7 +59,6 @@ export class OttofellerPlaywrightProject extends TypeScriptProject {
 
     // ANCHOR playwright config
     new SampleFile(this, 'playwright.config.ts', {sourcePath: path.join(assetsDir, 'playwright.config.ts.sample')})
-    new SampleFile(this, '.env.development', {sourcePath: path.join(assetsDir, '.env.development')})
 
     // eslint-disable-next-line @cspell/spellchecker -- the word is used once, so no need to add it to the dictionary
     this.addDeps('@playwright/test', 'playwright-qase-reporter')

--- a/src/playwright/sample-code.ts
+++ b/src/playwright/sample-code.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import * as projen from 'projen'
+import {SampleFile} from 'projen'
 import {OttofellerPlaywrightProject, OttofellerPlaywrightProjectOptions} from '.'
 
 /**
@@ -14,51 +14,21 @@ export function sampleCode(
     return
   }
 
-  new projen.SampleFile(project, 'common/index.ts', {
-    sourcePath: path.join(assetsDir, 'common/index.ts.sample'),
-  })
+  new SampleFile(project, '.env.development', {sourcePath: path.join(assetsDir, '.env.development')})
 
-  new projen.SampleFile(project, 'common/test.ts', {
-    sourcePath: path.join(assetsDir, 'common/test.ts.sample'),
-  })
+  new SampleFile(project, 'common/index.ts', {sourcePath: path.join(assetsDir, 'common/index.ts.sample')})
+  new SampleFile(project, 'common/test.ts', {sourcePath: path.join(assetsDir, 'common/test.ts.sample')})
+  new SampleFile(project, 'common/enums/user.ts', {sourcePath: path.join(assetsDir, 'common/enums/user.ts')})
+  new SampleFile(project, 'common/enums/index.ts', {sourcePath: path.join(assetsDir, 'common/enums/index.ts.sample')})
 
-  new projen.SampleFile(project, 'common/enums/user.ts', {
-    sourcePath: path.join(assetsDir, 'common/enums/user.ts'),
-  })
+  new SampleFile(project, 'data/index.ts', {sourcePath: path.join(assetsDir, 'data/index.ts')})
+  new SampleFile(project, 'data/errors.json', {sourcePath: path.join(assetsDir, 'data/errors.json')})
 
-  new projen.SampleFile(project, 'common/enums/index.ts', {
-    sourcePath: path.join(assetsDir, 'common/enums/index.ts.sample'),
-  })
+  new SampleFile(project, 'pages/index.ts', {sourcePath: path.join(assetsDir, 'pages/index.ts.sample')})
+  new SampleFile(project, 'pages/base.ts', {sourcePath: path.join(assetsDir, 'pages/base.ts.sample')})
+  new SampleFile(project, 'pages/index.ts', {sourcePath: path.join(assetsDir, 'pages/index.ts.sample')})
+  new SampleFile(project, 'pages/sign-in.ts', {sourcePath: path.join(assetsDir, 'pages/sign-in.ts.sample')})
+  new SampleFile(project, 'pages/products.ts', {sourcePath: path.join(assetsDir, 'pages/products.ts.sample')})
 
-  new projen.SampleFile(project, 'data/index.ts', {
-    sourcePath: path.join(assetsDir, 'data/index.ts'),
-  })
-
-  new projen.SampleFile(project, 'data/errors.json', {
-    sourcePath: path.join(assetsDir, 'data/errors.json'),
-  })
-
-  new projen.SampleFile(project, 'pages/index.ts', {
-    sourcePath: path.join(assetsDir, 'pages/index.ts.sample'),
-  })
-
-  new projen.SampleFile(project, 'pages/base.ts', {
-    sourcePath: path.join(assetsDir, 'pages/base.ts.sample'),
-  })
-
-  new projen.SampleFile(project, 'pages/index.ts', {
-    sourcePath: path.join(assetsDir, 'pages/index.ts.sample'),
-  })
-
-  new projen.SampleFile(project, 'pages/sign-in.ts', {
-    sourcePath: path.join(assetsDir, 'pages/sign-in.ts.sample'),
-  })
-
-  new projen.SampleFile(project, 'pages/products.ts', {
-    sourcePath: path.join(assetsDir, 'pages/products.ts.sample'),
-  })
-
-  new projen.SampleFile(project, 'specs/auth.spec.ts', {
-    sourcePath: path.join(assetsDir, 'specs/auth.spec.ts.sample'),
-  })
+  new SampleFile(project, 'specs/auth.spec.ts', {sourcePath: path.join(assetsDir, 'specs/auth.spec.ts.sample')})
 }


### PR DESCRIPTION
The `.env.development` file is currently not deletable and in order to stop its generation after deletion we need to hide it behind an option - `sampleCode` seems like the good fit.