### PR TITLE
Add node-fetch as a bundled dep

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -135,6 +135,10 @@
       "type": "bundled"
     },
     {
+      "name": "node-fetch",
+      "type": "bundled"
+    },
+    {
       "name": "prettier",
       "type": "bundled"
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -18,7 +18,7 @@ const project = new projen.cdk.JsiiProject({
   minNodeVersion: '16.0.0',
 
   deps: ['projen'],
-  bundledDeps: ['prettier', 'eslint'],
+  bundledDeps: ['prettier', 'eslint', 'node-fetch'],
   peerDeps: ['projen'],
   devDeps: ['@types/eslint', '@types/jscodeshift', '@graphql-codegen/cli', 'node-fetch@2', '@types/node-fetch'],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.8.15",
       "bundleDependencies": [
         "eslint",
+        "node-fetch",
         "prettier"
       ],
       "license": "Apache-2.0",
       "dependencies": {
         "eslint": "8.42.0",
+        "node-fetch": "^2.7.0",
         "prettier": "2.8.0",
         "projen": "^0.71.128"
       },
@@ -8153,6 +8155,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "inBundle": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -10418,7 +10421,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "inBundle": true
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -10884,13 +10888,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "inBundle": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "inBundle": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -67,11 +67,13 @@
   },
   "dependencies": {
     "eslint": "8.42.0",
+    "node-fetch": "^2.7.0",
     "prettier": "2.8.0",
     "projen": "^0.71.128"
   },
   "bundledDependencies": [
     "eslint",
+    "node-fetch",
     "prettier"
   ],
   "overrides": {


### PR DESCRIPTION
Closes PLA-274.

Without the bundled dep the template fails to bootstrap a new project. Even though the dependency is not used at the initial stage, it is referenced and thus must be resolved.