### PR TITLE
Fix incorrect telemetry call in workflow

### DIFF
--- a/src/common/telemetry/collect-telemetry/__tests__/index.ts
+++ b/src/common/telemetry/collect-telemetry/__tests__/index.ts
@@ -146,6 +146,7 @@ describe('collectTelemetry function', () => {
       },
       jobs: {
         telemetry: {
+          env: {IS_OTTOFELLER_TEMPLATES_TELEMETRY_COLLECTED: '1'},
           permissions: {contents: 'read'},
           runsOn: ['ubuntu-latest'],
           steps: [
@@ -173,7 +174,7 @@ describe('collectTelemetry function', () => {
             },
             {
               name: 'Execute the command',
-              run: 'yarn run IS_OTTOFELLER_TEMPLATES_TELEMETRY_COLLECTED=1 npm run default',
+              run: 'yarn run default',
             },
           ],
         },

--- a/src/common/telemetry/telemetry-workflow.ts
+++ b/src/common/telemetry/telemetry-workflow.ts
@@ -42,14 +42,14 @@ export class TelemetryWorkflow extends Component {
     workflow.on({pullRequest: {paths, types: ['opened', 'synchronize']}})
 
     const telemetryJob = runScriptJob({
-      command: `${telemetryEnableEnvVar}=1 npm run default`,
+      command: 'default',
       workingDirectory,
       projectPackage: project.package,
       runScriptCommand: project.runScriptCommand,
       nodeVersion,
     })
 
-    workflow.addJob('telemetry', telemetryJob)
+    workflow.addJob('telemetry', {...telemetryJob, env: {[telemetryEnableEnvVar]: '1'}})
   }
 
   /**


### PR DESCRIPTION
Env vars can't be inserted in the call, thus the variable need to be moved into a proper section and the command only calls the necessary script.