### PR TITLE
Add telemetry to options to all projects

### DIFF
--- a/src/apollo-server/index.ts
+++ b/src/apollo-server/index.ts
@@ -8,7 +8,7 @@ import {AssetFile} from '../common/files/AssetFile'
 import {WithGitHooks, addHusky, extendGitignore} from '../common/git'
 import {PullRequestTest, WithDefaultWorkflow} from '../common/github'
 import {WithCustomLintPaths, addLinters} from '../common/lint'
-import {IWithTelemetryReportUrl, collectTelemetry, setupTelemetry} from '../common/telemetry'
+import {IWithTelemetryReportUrl, WithTelemetry, collectTelemetry, setupTelemetry} from '../common/telemetry'
 import {addVsCode} from '../common/vscode-settings'
 import {sampleCode} from './sample-code'
 
@@ -17,7 +17,8 @@ export interface OttofellerApolloServerProjectOptions
     WithDocker,
     WithDefaultWorkflow,
     WithCustomLintPaths,
-    WithGitHooks {}
+    WithGitHooks,
+    WithTelemetry {}
 
 /**
  * Apollo server template.

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -5,14 +5,15 @@ import {NodePackageManager} from 'projen/lib/javascript'
 import {WithGitHooks, addHusky, extendGitignore} from '../common/git'
 import {PullRequestTest, ReleaseWorkflow, WithDefaultWorkflow} from '../common/github'
 import {WithCustomLintPaths, addLinters} from '../common/lint'
-import {IWithTelemetryReportUrl, collectTelemetry, setupTelemetry} from '../common/telemetry'
+import {IWithTelemetryReportUrl, WithTelemetry, collectTelemetry, setupTelemetry} from '../common/telemetry'
 import {addVsCode} from '../common/vscode-settings'
 
 export interface OttofellerCDKProjectOptions
   extends AwsCdkTypeScriptAppOptions,
     WithDefaultWorkflow,
     WithCustomLintPaths,
-    WithGitHooks {
+    WithGitHooks,
+    WithTelemetry {
   /**
    * The base version of the very first release.
    *

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -5,7 +5,7 @@ import {NodePackageManager} from 'projen/lib/javascript'
 import {TypeScriptProject, TypeScriptProjectOptions} from 'projen/lib/typescript'
 import {WithDefaultWorkflow, WithDocker, WithGitHooks} from '../common'
 import {WithCustomLintPaths, addLinters} from '../common/lint'
-import {IWithTelemetryReportUrl, collectTelemetry, setupTelemetry} from '../common/telemetry'
+import {IWithTelemetryReportUrl, WithTelemetry, collectTelemetry, setupTelemetry} from '../common/telemetry'
 import {PlaywrightWorkflowTest} from './github'
 import {sampleCode} from './sample-code'
 
@@ -14,7 +14,8 @@ export interface OttofellerPlaywrightProjectOptions
     WithDocker,
     WithDefaultWorkflow,
     WithCustomLintPaths,
-    WithGitHooks {}
+    WithGitHooks,
+    WithTelemetry {}
 /**
  * Playwright template with TypeScript support.
  *

--- a/src/sst/index.ts
+++ b/src/sst/index.ts
@@ -7,14 +7,15 @@ import {TypeScriptAppProject, TypeScriptProjectOptions} from 'projen/lib/typescr
 import {WithGitHooks, addHusky, extendGitignore} from '../common/git'
 import {PullRequestTest, ReleaseWorkflow, WithDefaultWorkflow} from '../common/github'
 import {WithCustomLintPaths, addLinters} from '../common/lint'
-import {IWithTelemetryReportUrl, collectTelemetry, setupTelemetry} from '../common/telemetry'
+import {IWithTelemetryReportUrl, WithTelemetry, collectTelemetry, setupTelemetry} from '../common/telemetry'
 import {addVsCode} from '../common/vscode-settings'
 
 export interface OttofellerSSTProjectOptions
   extends TypeScriptProjectOptions,
     WithDefaultWorkflow,
     WithCustomLintPaths,
-    WithGitHooks {
+    WithGitHooks,
+    WithTelemetry {
   /**
    * The base version of the very first release.
    *


### PR DESCRIPTION
Without this type extension one cannot set telemetry options in any project but nextjs (unless a `ts-ignore` comment is used).