### PR TITLE
Telemetry: remove empty objects from collected escape hatches

### DIFF
--- a/src/common/telemetry/collect-telemetry/__tests__/index.ts
+++ b/src/common/telemetry/collect-telemetry/__tests__/index.ts
@@ -129,6 +129,25 @@ describe('collectTelemetry function', () => {
     expect(mockedNodeFetch).toBeCalledWith(telemetryOptions.telemetryUrl, fetchOptions)
   })
 
+  test('does not collect empty escape hatches', () => {
+    const project = new TestProject(telemetryOptions)
+    // NOTE: Only this single item will be recorded
+    const escapeHatches = {files: {tryFindFile: "'.eslintrc.json'"}}
+
+    const projenrcTs = [
+      "import {OttofellerNextjsProject} from '@ottofeller/templates'",
+      'const project = new OttofellerNextjsProject({})',
+      `const eslintrc = project.tryFindFile(${escapeHatches.files.tryFindFile}) as unknown as ObjectFile`,
+      'project.synth()',
+    ].join('\n')
+
+    mockedReadFileSync.mockReturnValue(projenrcTs)
+    collectTelemetry(project)
+
+    expect(mockStringify).toHaveBeenLastCalledWith(expect.objectContaining({escapeHatches}))
+    expect(mockedNodeFetch).toHaveBeenLastCalledWith(telemetryOptions.telemetryUrl, fetchOptions)
+  })
+
   test('collects GitHub workflow data', () => {
     const project = new TestProject(telemetryOptions)
     const updatedWorkflowName = 'build'

--- a/src/common/telemetry/collect-telemetry/collect-escape-hatches.ts
+++ b/src/common/telemetry/collect-telemetry/collect-escape-hatches.ts
@@ -11,11 +11,15 @@ export type EscapeHatches = Record<string, MaybePlural<string>>
  *
  * @returns A mapping object between found method calls and the call arguments.
  */
-export const collectEscapeHatches = (source: string, methods: Array<string>): EscapeHatches => {
+export const collectEscapeHatches = (source: string, methods: Array<string>): EscapeHatches | undefined => {
   const regex = new RegExp(`\\.(${methods.join('|')})\\((.*)\\)`, 'g')
-  const handles = source.matchAll(regex)
+  const handles = Array.from(source.matchAll(regex))
 
-  return Array.from(handles).reduce<EscapeHatches>((acc, [, method, args]) => {
+  if (handles.length < 1) {
+    return
+  }
+
+  return handles.reduce<EscapeHatches>((acc, [, method, args]) => {
     if (!acc[method]) {
       acc[method] = args
       return acc


### PR DESCRIPTION
Without this update the `escapeHatches` object is always non-empty because of its keys are always objects, even when there are no entries found in source code.