### PR TITLE
Setup optional telemetry authorization

### DIFF
--- a/src/common/telemetry/__tests__/index.ts
+++ b/src/common/telemetry/__tests__/index.ts
@@ -1,15 +1,19 @@
 import {NodeProject, NodeProjectOptions} from 'projen/lib/javascript'
 import {synthSnapshot} from 'projen/lib/util/synth'
+import * as YAML from 'yaml'
 import {IWithTelemetryReportUrl, WithTelemetry, setupTelemetry} from '..'
+import {telemetryAuthToken} from '../collect-telemetry'
 
 describe('setupTelemetry function', () => {
+  const telemetryWorkflowPath = '.github/workflows/telemetry.yml'
+
   test('does nothing if telemetry options are not provided', () => {
     const project = new TestProject()
     setupTelemetry(project, {})
     expect(project.telemetryReportUrl).toBeUndefined()
 
     const snapshot = synthSnapshot(project)
-    const telemetryWorkflow = snapshot['.github/workflows/telemetry.yml']
+    const telemetryWorkflow = snapshot[telemetryWorkflowPath]
     expect(telemetryWorkflow).toBeUndefined()
   })
 
@@ -19,13 +23,38 @@ describe('setupTelemetry function', () => {
     expect(project.telemetryReportUrl).toBeDefined()
 
     const snapshot = synthSnapshot(project)
-    const telemetryWorkflow = snapshot['.github/workflows/telemetry.yml']
+    const telemetryWorkflow = snapshot[telemetryWorkflowPath]
     expect(telemetryWorkflow).toBeDefined()
+    const {IS_OTTOFELLER_TEMPLATES_TELEMETRY_COLLECTED} = YAML.parse(telemetryWorkflow).jobs.telemetry.env
+    expect(IS_OTTOFELLER_TEMPLATES_TELEMETRY_COLLECTED).toBeTruthy()
+  })
+
+  test('sets up telemetry authorization', () => {
+    const project = new TestProject({})
+    const telemetryAuthHeader = 'Some-Header'
+    const telemetryAuthTokenVar = 'Some-Secret'
+
+    setupTelemetry(project, {
+      isTelemetryEnabled: true,
+      telemetryUrl: 'http://localhost:3000/telemetry',
+      telemetryAuthHeader,
+      telemetryAuthTokenVar,
+    })
+
+    expect(project.telemetryReportUrl).toBeDefined()
+    expect(project.telemetryAuthHeader).toBeDefined()
+
+    const snapshot = synthSnapshot(project)
+    const telemetryWorkflow = snapshot[telemetryWorkflowPath]
+    expect(telemetryWorkflow).toBeDefined()
+    const {env} = YAML.parse(telemetryWorkflow).jobs.telemetry
+    expect(env[telemetryAuthToken]).toEqual(`\${{ secrets.${telemetryAuthTokenVar} }}`)
   })
 })
 
 class TestProject extends NodeProject implements IWithTelemetryReportUrl {
   readonly telemetryReportUrl?: string
+  readonly telemetryAuthHeader?: string
 
   constructor(options: Partial<NodeProjectOptions & WithTelemetry> = {}) {
     super({

--- a/src/common/telemetry/collect-telemetry/collect-telemetry.ts
+++ b/src/common/telemetry/collect-telemetry/collect-telemetry.ts
@@ -54,6 +54,7 @@ interface TelemetryPayload {
 }
 
 export const telemetryEnableEnvVar = 'IS_OTTOFELLER_TEMPLATES_TELEMETRY_COLLECTED' as const
+export const telemetryAuthToken = 'TELEMETRY_AUTH_TOKEN' as const
 
 export const collectTelemetry = async (project: NodeProject & IWithTelemetryReportUrl) => {
   if (!project.telemetryReportUrl || !process.env[telemetryEnableEnvVar]) {
@@ -171,7 +172,14 @@ export const collectTelemetry = async (project: NodeProject & IWithTelemetryRepo
   try {
     const body = JSON.stringify(payload)
     project.logger.info('Collected telemetry:', body)
-    const {status, statusText} = await fetch(project.telemetryReportUrl!, {method: 'post', body})
+    const headers: Record<string, string> = {}
+    const authHeaderName = project.telemetryAuthHeader
+
+    if (authHeaderName) {
+      headers[authHeaderName] = process.env[telemetryAuthToken]!
+    }
+
+    const {status, statusText} = await fetch(project.telemetryReportUrl!, {method: 'post', body, headers})
     project.logger.info('Telemetry endpoint responded with status', status, statusText)
   } catch (e) {
     project.logger.error('Telemetry serialization or network error', e)

--- a/src/common/telemetry/i-with-telemetry-report-url.ts
+++ b/src/common/telemetry/i-with-telemetry-report-url.ts
@@ -3,4 +3,9 @@ export interface IWithTelemetryReportUrl {
    * URL used for telemetry.
    */
   readonly telemetryReportUrl?: string
+
+  /**
+   * Authorization header name for telemetry
+   */
+  readonly telemetryAuthHeader?: string
 }

--- a/src/common/telemetry/setup-telemetry.ts
+++ b/src/common/telemetry/setup-telemetry.ts
@@ -15,10 +15,13 @@ export const setupTelemetry = (
   project: NodeProject & Writeable<IWithTelemetryReportUrl>,
   options: WithTelemetry & TelemetryWorkflowOptions,
 ) => {
-  const {isTelemetryEnabled = false, telemetryUrl} = options
+  const {isTelemetryEnabled = false, telemetryUrl, telemetryAuthHeader, telemetryAuthTokenVar} = options
+  const anyOfOptionalTelemetryParams = telemetryUrl || telemetryAuthHeader || telemetryAuthTokenVar
 
-  if (!isTelemetryEnabled && telemetryUrl) {
-    throw Error('Telemetry is disabled, thus "telemetryUrl" won\'t have any effect.')
+  if (!isTelemetryEnabled && anyOfOptionalTelemetryParams) {
+    throw new Error(
+      'Telemetry is disabled, thus "telemetryUrl", "telemetryAuthHeader" or "telemetryAuthTokenVar" won\'t have any effect.',
+    )
   }
 
   if (!isTelemetryEnabled) {
@@ -26,9 +29,18 @@ export const setupTelemetry = (
   }
 
   if (!telemetryUrl) {
-    throw Error('A valid URL is required to be set for telemetry.')
+    throw new Error('A valid URL is required to be set for telemetry.')
+  }
+
+  if ((telemetryAuthHeader && !telemetryAuthTokenVar) || (!telemetryAuthHeader && telemetryAuthTokenVar)) {
+    throw new Error('"telemetryAuthHeader" and "telemetryAuthTokenVar" options should be both set or not.')
   }
 
   project.telemetryReportUrl = telemetryUrl
+
+  if (telemetryAuthHeader) {
+    project.telemetryAuthHeader = telemetryAuthHeader
+  }
+
   TelemetryWorkflow.addToProject(project, options)
 }

--- a/src/common/telemetry/telemetry-workflow.ts
+++ b/src/common/telemetry/telemetry-workflow.ts
@@ -2,14 +2,16 @@ import {Component, ProjenrcFile} from 'projen'
 import type {GitHub} from 'projen/lib/github'
 import {NodeProject, NodeProjectOptions} from 'projen/lib/javascript'
 import {runScriptJob} from '../github'
-import {telemetryEnableEnvVar} from './collect-telemetry'
+import {telemetryAuthToken, telemetryEnableEnvVar} from './collect-telemetry'
+import type {WithTelemetry} from './with-telemetry'
 
 /**
  * Options for PullRequestLint
  */
 export interface TelemetryWorkflowOptions
   extends Partial<Pick<NodeProject, 'runScriptCommand'>>,
-    Pick<NodeProjectOptions, 'workflowNodeVersion'> {
+    Pick<NodeProjectOptions, 'workflowNodeVersion'>,
+    Pick<WithTelemetry, 'telemetryAuthTokenVar'> {
   /**
    * Project name - used to construct workflow name for subprojects
    */
@@ -49,7 +51,14 @@ export class TelemetryWorkflow extends Component {
       nodeVersion,
     })
 
-    workflow.addJob('telemetry', {...telemetryJob, env: {[telemetryEnableEnvVar]: '1'}})
+    const env: Record<string, string> = {[telemetryEnableEnvVar]: '1'}
+    const {telemetryAuthTokenVar} = options
+
+    if (telemetryAuthTokenVar) {
+      env[telemetryAuthToken] = `\${{ secrets.${telemetryAuthTokenVar} }}`
+    }
+
+    workflow.addJob('telemetry', {...telemetryJob, env})
   }
 
   /**
@@ -57,18 +66,18 @@ export class TelemetryWorkflow extends Component {
    * or within the project parent (for subprojects).
    */
   static addToProject(project: NodeProject, options: TelemetryWorkflowOptions) {
-    const {outdir, workflowNodeVersion} = options
+    const {outdir, workflowNodeVersion, telemetryAuthTokenVar} = options
+    const commonOptions = {outdir, workflowNodeVersion, telemetryAuthTokenVar}
 
     if (project.github) {
-      new TelemetryWorkflow(project.github, {outdir, workflowNodeVersion})
+      new TelemetryWorkflow(project.github, commonOptions)
       return
     }
 
     if (project.parent && project.parent instanceof NodeProject && project.parent.github) {
       new TelemetryWorkflow(project.parent.github, {
         name: `telemetry-${options.name}`,
-        outdir,
-        workflowNodeVersion,
+        ...commonOptions,
       })
     }
   }

--- a/src/common/telemetry/with-telemetry.ts
+++ b/src/common/telemetry/with-telemetry.ts
@@ -12,4 +12,15 @@ export interface WithTelemetry {
    * Endpoint URL to send telemetry data to.
    */
   readonly telemetryUrl?: string
+
+  /**
+   * Authorization header name for telemetry
+   */
+  readonly telemetryAuthHeader?: string
+
+  /**
+   * The name of env var to extract header value from.
+   * The value is expected to be stored in a CI secret.
+   */
+  readonly telemetryAuthTokenVar?: string
 }


### PR DESCRIPTION
Closes PLA-277.

If telemetry endpoint requires authorisation, it can be provided in form of a header. Two additional options are defined:
- header name,
- GitHub secret name to pull the token from.