### PR TITLE
Automatically detect projenrc file in addLinters function

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -100,10 +100,10 @@
       "description": "Perform code formatting and fixes of code-quality rules",
       "steps": [
         {
-          "exec": "prettier --write .projenrc.ts src"
+          "exec": "prettier --write src .projenrc.ts"
         },
         {
-          "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern \"!.projenrc.ts\" .projenrc.ts src --fix"
+          "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern \"!.projenrc.ts\" src .projenrc.ts --fix"
         }
       ]
     },
@@ -130,10 +130,10 @@
       "description": "Check code formatting and code-quality rules",
       "steps": [
         {
-          "exec": "prettier --check .projenrc.ts src"
+          "exec": "prettier --check src .projenrc.ts"
         },
         {
-          "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern \"!.projenrc.ts\" .projenrc.ts src"
+          "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern \"!.projenrc.ts\" src .projenrc.ts"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -72,7 +72,7 @@ const rules: Linter.RulesRecord = {
 
 addLinters({
   project,
-  lintPaths: ['.projenrc.ts', 'src'],
+  lintPaths: ['src'],
   extraEslintConfigs: [{rules}],
 })
 

--- a/src/apollo-server/__tests__/__snapshots__/index.ts.snap
+++ b/src/apollo-server/__tests__/__snapshots__/index.ts.snap
@@ -775,10 +775,10 @@ tsconfig.tsbuildinfo
         "name": "format",
         "steps": [
           {
-            "exec": "prettier --write .projenrc.mjs src",
+            "exec": "prettier --write src .projenrc.mjs",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" .projenrc.mjs src --fix",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" src .projenrc.mjs --fix",
           },
         ],
       },
@@ -805,10 +805,10 @@ tsconfig.tsbuildinfo
         "name": "lint",
         "steps": [
           {
-            "exec": "prettier --check .projenrc.mjs src",
+            "exec": "prettier --check src .projenrc.mjs",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" .projenrc.mjs src",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.mjs" src .projenrc.mjs",
           },
         ],
       },

--- a/src/apollo-server/index.ts
+++ b/src/apollo-server/index.ts
@@ -152,7 +152,7 @@ export class OttofellerApolloServerProject extends TypeScriptAppProject implemen
     }
 
     // ANCHOR ESLint and prettier setup
-    const lintPaths = options.lintPaths ?? ['.projenrc.mjs', 'src']
+    const lintPaths = options.lintPaths ?? ['src']
     addLinters({project: this, lintPaths})
 
     // ANCHOR Github workflow

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -663,10 +663,10 @@ cdk.out/
         "name": "format",
         "steps": [
           {
-            "exec": "prettier --write .projenrc.ts src",
+            "exec": "prettier --write src .projenrc.ts",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts src --fix",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" src .projenrc.ts --fix",
           },
         ],
       },
@@ -693,10 +693,10 @@ cdk.out/
         "name": "lint",
         "steps": [
           {
-            "exec": "prettier --check .projenrc.ts src",
+            "exec": "prettier --check src .projenrc.ts",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts src",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" src .projenrc.ts",
           },
         ],
       },

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -118,7 +118,7 @@ export class OttofellerCDKProject extends AwsCdkTypeScriptApp implements IWithTe
     }
 
     // ANCHOR ESLint and prettier setup
-    const lintPaths = options.lintPaths ?? ['.projenrc.ts', 'src']
+    const lintPaths = options.lintPaths ?? ['src']
     addLinters({project: this, lintPaths})
 
     // ANCHOR Github

--- a/src/common/lint/add-linters.ts
+++ b/src/common/lint/add-linters.ts
@@ -1,5 +1,5 @@
 import type {Linter} from 'eslint'
-import {JsonFile, SampleFile} from 'projen'
+import {JsonFile, ProjenrcFile, SampleFile} from 'projen'
 import {NodeProject} from 'projen/lib/javascript'
 import {deepMerge} from 'projen/lib/util'
 import {addTaskOrScript} from '../tasks/add-task-or-script'
@@ -37,10 +37,13 @@ export const addLinters = (props: AddLintersProps): void => {
   project.addDevDeps(...linterDependencies)
 
   // ANCHOR Scripts
-  const projenrcRegex = /.projenrc.(?:js|mjs|ts|json)/
-  const filterPredicate = project.parent ? (path: string) => !projenrcRegex.test(path) : Boolean
-  const filteredPaths = lintPaths.filter(filterPredicate).join(' ')
-  const projenrcFile = filteredPaths.match(projenrcRegex)?.[0]
+  const projenrcFile = ProjenrcFile.of(project)?.filePath
+
+  const filteredPaths = lintPaths
+    .concat(projenrcFile ?? '')
+    .filter(Boolean)
+    .join(' ')
+
   const includeOption = projenrcFile ? `--ignore-pattern "!${projenrcFile}" ` : ''
   const eslintRunCommand = `eslint --ext .js,.jsx,.ts,.tsx ${includeOption}${filteredPaths}`
 

--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -865,10 +865,10 @@ tsconfig.tsbuildinfo
         "name": "format",
         "steps": [
           {
-            "exec": "prettier --write .projenrc.ts app src",
+            "exec": "prettier --write app src .projenrc.ts",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts app src --fix",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" app src .projenrc.ts --fix",
           },
         ],
       },
@@ -895,10 +895,10 @@ tsconfig.tsbuildinfo
         "name": "lint",
         "steps": [
           {
-            "exec": "prettier --check .projenrc.ts app src",
+            "exec": "prettier --check app src .projenrc.ts",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts app src",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" app src .projenrc.ts",
           },
         ],
       },

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -140,7 +140,7 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject implements 
     new SampleFile(this, 'next-env.d.ts', {sourcePath: path.join(assetsDir, 'next-env.d.ts.sample')})
 
     // ANCHOR ESLint and prettier setup
-    const lintPaths = options.lintPaths ?? ['.projenrc.ts', 'app', 'src']
+    const lintPaths = options.lintPaths ?? ['app', 'src']
     const extraEslintConfigs = [eslintConfigReact]
 
     if (options.isUiConfigEnabled ?? true) {

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -101,7 +101,7 @@ export class OttofellerPlaywrightProject extends TypeScriptProject implements IW
     tasksToRemove.forEach(this.removeTask.bind(this))
 
     // ANCHOR ESLint and prettier setup
-    const lintPaths = options.lintPaths ?? ['.projenrc.ts', 'src']
+    const lintPaths = options.lintPaths ?? ['src']
     addLinters({project: this, lintPaths})
 
     // ANCHOR Github workflow

--- a/src/sst/__tests__/__snapshots__/index.ts.snap
+++ b/src/sst/__tests__/__snapshots__/index.ts.snap
@@ -685,10 +685,10 @@ tsconfig.tsbuildinfo
         "name": "format",
         "steps": [
           {
-            "exec": "prettier --write .projenrc.ts stacks sst.config.ts",
+            "exec": "prettier --write stacks sst.config.ts .projenrc.ts",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts stacks sst.config.ts --fix",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" stacks sst.config.ts .projenrc.ts --fix",
           },
         ],
       },
@@ -715,10 +715,10 @@ tsconfig.tsbuildinfo
         "name": "lint",
         "steps": [
           {
-            "exec": "prettier --check .projenrc.ts stacks sst.config.ts",
+            "exec": "prettier --check stacks sst.config.ts .projenrc.ts",
           },
           {
-            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" .projenrc.ts stacks sst.config.ts",
+            "exec": "eslint --ext .js,.jsx,.ts,.tsx --ignore-pattern "!.projenrc.ts" stacks sst.config.ts .projenrc.ts",
           },
         ],
       },

--- a/src/sst/index.ts
+++ b/src/sst/index.ts
@@ -92,7 +92,7 @@ export class OttofellerSSTProject extends TypeScriptAppProject implements IWithT
     }
 
     // ANCHOR ESLint and prettier setup
-    const lintPaths = options.lintPaths ?? ['.projenrc.ts', 'stacks', 'sst.config.ts']
+    const lintPaths = options.lintPaths ?? ['stacks', 'sst.config.ts']
     addLinters({project: this, lintPaths})
 
     // ANCHOR Github


### PR DESCRIPTION
With the update the `.projenrc.{ext}` is resolved automatically - the file is added to search patterns only when present, and the extension is resolved from the actual file without manual adjustments.

In addition some of the test of the `addLinters` function were found to be corrupt after the switch from _npm_ scripts to _projen_ tasks. The tests are updated to fit the current logic.

Closes PLA-281.