### PR TITLE
Use cache for rust test workflow

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -67,6 +67,7 @@
     "Println",
     "projen",
     "projenrc",
+    "rustc",
     "rustfmt",
     "testid",
     "timestamptz",

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -80,10 +80,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-clippy
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
@@ -97,10 +107,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-check
       - name: Run check
         uses: actions-rs/cargo@v1
         env:
@@ -115,10 +135,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-fmt
       - name: Run fmt
         uses: actions-rs/cargo@v1
         with:
@@ -132,10 +162,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-test
       - name: Run test
         uses: actions-rs/cargo@v1
         with:

--- a/src/common/github/__tests__/__snapshots__/index.ts.snap
+++ b/src/common/github/__tests__/__snapshots__/index.ts.snap
@@ -3928,10 +3928,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-clippy
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
@@ -3945,10 +3955,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-check
       - name: Run check
         uses: actions-rs/cargo@v1
         env:
@@ -3963,10 +3983,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-fmt
       - name: Run fmt
         uses: actions-rs/cargo@v1
         with:
@@ -3980,10 +4010,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt, clippy
+      - uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-\${{ runner.os }}-\${{ steps.toolchain.outputs.rustc_hash }}-\${{ hashFiles('**/Cargo.lock') }}-test
       - name: Run test
         uses: actions-rs/cargo@v1
         with:

--- a/src/common/github/rust-test-workflow.ts
+++ b/src/common/github/rust-test-workflow.ts
@@ -88,8 +88,28 @@ export class RustTestWorkflow extends GithubWorkflow {
           {uses: 'actions/checkout@v3'},
           {
             name: 'Install latest nightly',
+            id: 'toolchain',
             uses: 'actions-rs/toolchain@v1',
             with: {toolchain, components: 'rustfmt, clippy'},
+          },
+          {
+            uses: 'actions/cache@v3',
+            with: {
+              path: [
+                '~/.cargo/bin/',
+                '~/.cargo/registry/index/',
+                '~/.cargo/registry/cache/',
+                '~/.cargo/git/db/',
+                'target/',
+              ].join('\n'),
+              key: [
+                'cargo',
+                '${{ runner.os }}',
+                '${{ steps.toolchain.outputs.rustc_hash }}',
+                "${{ hashFiles('**/Cargo.lock') }}",
+                command,
+              ].join('-'),
+            },
           },
           {
             name: `Run ${command}`,


### PR DESCRIPTION
Closes PLA-292.

In the chosen caching schema:
- CARGO_HOME and target folders are cached in a single step;
- each job has its own cache;
- the caches are updated daily (because of nightly updates to rust).