### PR TITLE
Remove only statement on a rest workflow test

### DIFF
--- a/src/common/github/__tests__/index.ts
+++ b/src/common/github/__tests__/index.ts
@@ -485,7 +485,7 @@ describe('GitHub utils', () => {
       expect(commands).toContain('test')
     })
 
-    test.only('enables additional lints in cargo check', () => {
+    test('enables additional lints in cargo check', () => {
       const project = new TestProject()
       new RustTestWorkflow(project.github!)
       const snapshot = synthSnapshot(project)


### PR DESCRIPTION
The only statement was erroneously left there. Without the statement 53 test cases are unskipped.