### PR TITLE
Remove cspell config and examples from published files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,9 +17,11 @@ dist
 /.projenrc.js
 tsconfig.tsbuildinfo
 !.jsii
+/cspell.json
 /.eslintrc.json
 /.prettierrc.json
 /.projenrc.ts
+/examples/
 /src/**
 /lib/**/assets/**
 **/__tests__/**

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -168,9 +168,11 @@ publishReleaseGithubWorkflow.addJobs({
 
 // ANCHOR nmpignore
 project.npmignore!.exclude(
+  '/cspell.json',
   '/.eslintrc.json',
   '/.prettierrc.json',
   '/.projenrc.ts',
+  '/examples/',
   '/src/**',
   '/lib/**/assets/**',
   '**/__tests__/**',


### PR DESCRIPTION
The files under consideration are irrelevant for production and hence can be removed from the published package.
- `cspell.josn` is a development config. 
- The `examples` folder contains usage examples and complements the documentation in readme. Even though one might want to look up examples, the `node_modules` is not a usual destination, where a developer seeks this info. All the documentation is still available on GitHub.