### PR TITLE
Run projen drift check on all changes

### DIFF
--- a/.github/workflows/projen-drift-check.yml
+++ b/.github/workflows/projen-drift-check.yml
@@ -3,16 +3,10 @@
 name: projen-drift-check
 on:
   pull_request:
-    paths:
-      - .projenrc.ts
-      - src/common/**
     types:
       - opened
       - synchronize
   push:
-    paths:
-      - .projenrc.ts
-      - src/common/**
     branches:
       - main
 jobs:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -94,7 +94,7 @@ testGithubWorkflow.addJobs({
   build: {...job([npmRunJobStep('build')]), needs: ['lint', 'test', 'typecheck']},
 })
 
-new ProjenDriftCheckWorkflow(project.github!, {additionalPaths: ['src/common/**']})
+new ProjenDriftCheckWorkflow(project.github!, {})
 
 const createReleaseGithubWorkflow = project.github!.addWorkflow('create-release')
 

--- a/src/apollo-server/__tests__/__snapshots__/index.ts.snap
+++ b/src/apollo-server/__tests__/__snapshots__/index.ts.snap
@@ -335,14 +335,10 @@ updates:
 name: projen-drift-check
 on:
   pull_request:
-    paths:
-      - .projenrc.mjs
     types:
       - opened
       - synchronize
   push:
-    paths:
-      - .projenrc.mjs
     branches:
       - main
 jobs:

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -416,14 +416,10 @@ updates:
 name: projen-drift-check
 on:
   pull_request:
-    paths:
-      - .projenrc.ts
     types:
       - opened
       - synchronize
   push:
-    paths:
-      - .projenrc.ts
     branches:
       - main
 jobs:

--- a/src/common/github/__tests__/__snapshots__/index.ts.snap
+++ b/src/common/github/__tests__/__snapshots__/index.ts.snap
@@ -1037,14 +1037,10 @@ jobs:
 name: projen-drift-check
 on:
   pull_request:
-    paths:
-      - .projenrc.js
     types:
       - opened
       - synchronize
   push:
-    paths:
-      - .projenrc.js
     branches:
       - main
 jobs:

--- a/src/common/github/__tests__/index.ts
+++ b/src/common/github/__tests__/index.ts
@@ -257,42 +257,26 @@ describe('GitHub utils', () => {
 
     test('configures the workflow to be run on pull requests and pushes to main branch with changes to projenrc file', () => {
       const project = new TestProject()
-      const paths = ['.projenrc.js']
       new ProjenDriftCheckWorkflow(project.github!)
       const snapshot = synthSnapshot(project)
       const workflow = YAML.parse(snapshot[workflowPath])
 
       expect(workflow.on).toEqual({
-        pull_request: {paths, types: ['opened', 'synchronize']},
-        push: {paths, branches: ['main']},
-      })
-    })
-
-    test('allows setting additional paths to trigger the workflow', () => {
-      const additionalPaths = ['some/additional/path', 'another/additional/path']
-      const project = new TestProject()
-      const paths = ['.projenrc.js', ...additionalPaths]
-      new ProjenDriftCheckWorkflow(project.github!, {additionalPaths})
-      const snapshot = synthSnapshot(project)
-      const workflow = YAML.parse(snapshot[workflowPath])
-
-      expect(workflow.on).toEqual({
-        pull_request: {paths, types: ['opened', 'synchronize']},
-        push: {paths, branches: ['main']},
+        pull_request: {types: ['opened', 'synchronize']},
+        push: {branches: ['main']},
       })
     })
 
     test('allows to be run on pushes to specified branches', () => {
       const project = new TestProject()
       const branches = ['main', 'dev']
-      const paths = ['.projenrc.js']
       new ProjenDriftCheckWorkflow(project.github!, {triggerOnPushToBranches: branches})
       const snapshot = synthSnapshot(project)
       const workflow = YAML.parse(snapshot[workflowPath])
 
       expect(workflow.on).toEqual({
-        pull_request: {paths, types: ['opened', 'synchronize']},
-        push: {paths, branches},
+        pull_request: {types: ['opened', 'synchronize']},
+        push: {branches},
       })
     })
 

--- a/src/common/github/projen-drift-check-workflow.ts
+++ b/src/common/github/projen-drift-check-workflow.ts
@@ -1,4 +1,4 @@
-import {Component, ProjenrcFile, github, javascript} from 'projen'
+import {Component, github, javascript} from 'projen'
 import {NodeProject, NodeProjectOptions} from 'projen/lib/javascript'
 import {runScriptJob} from './jobs'
 import type {WithDefaultWorkflow} from './with-default-workflow'
@@ -25,12 +25,6 @@ export interface ProjenDriftCheckOptions
    * @default ['main']
    */
   readonly triggerOnPushToBranches?: Array<string>
-
-  /**
-   * By default the check runs only on projenrc file changes.
-   * This option allows adding paths that trigger the check.
-   */
-  readonly additionalPaths?: string[]
 }
 
 /**
@@ -47,15 +41,13 @@ export class ProjenDriftCheckWorkflow extends Component {
 
     const workflowName = 'projen-drift-check'
     const workingDirectory = options.outdir
-    const additionalPaths = options.additionalPaths ?? []
-    const paths = [ProjenrcFile.of(project)!.filePath, ...additionalPaths]
     const workflow = githubInstance.addWorkflow(workflowName)
     const branches = options.triggerOnPushToBranches ?? ['main']
     const nodeVersion = options.workflowNodeVersion ?? project.package.minNodeVersion
 
     workflow.on({
-      pullRequest: {paths, types: ['opened', 'synchronize']},
-      push: {paths, branches},
+      pullRequest: {types: ['opened', 'synchronize']},
+      push: {branches},
     })
 
     const uncomittedChangesJob = runScriptJob({

--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -395,14 +395,10 @@ updates:
 name: projen-drift-check
 on:
   pull_request:
-    paths:
-      - .projenrc.ts
     types:
       - opened
       - synchronize
   push:
-    paths:
-      - .projenrc.ts
     branches:
       - main
 jobs:

--- a/src/sst/__tests__/__snapshots__/index.ts.snap
+++ b/src/sst/__tests__/__snapshots__/index.ts.snap
@@ -313,14 +313,10 @@ updates:
 name: projen-drift-check
 on:
   pull_request:
-    paths:
-      - .projenrc.ts
     types:
       - opened
       - synchronize
   push:
-    paths:
-      - .projenrc.ts
     branches:
       - main
 jobs:


### PR DESCRIPTION
The purpose is to be able to catch all manual changes to projen-managed files.

Closes PLA-296.