### PR TITLE
Update github actions to latest version

### DIFF
--- a/.github/workflows/projen-drift-check.yml
+++ b/.github/workflows/projen-drift-check.yml
@@ -15,15 +15,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.0.0
+          node-version: 20.0.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,15 +22,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -45,15 +45,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -68,15 +68,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -36,15 +36,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -58,15 +58,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -84,15 +84,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^16",
+      "version": "^20",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -15,7 +15,7 @@ const project = new projen.cdk.JsiiProject({
   description: 'Projen templates for OttoFeller projects',
   packageName: '@ottofeller/templates',
   packageManager: projen.javascript.NodePackageManager.NPM,
-  minNodeVersion: '16.0.0',
+  minNodeVersion: '20.0.0',
 
   deps: ['projen'],
   bundledDeps: ['prettier', 'eslint', 'node-fetch'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/eslint": "8.40.0",
         "@types/jest": "29",
         "@types/jscodeshift": "^0.11.6",
-        "@types/node": "^16",
+        "@types/node": "^20",
         "@types/node-fetch": "^2.6.6",
         "@types/prettier": "2.6.0",
         "@typescript-eslint/eslint-plugin": "6",
@@ -51,7 +51,7 @@
         "typescript": "5.3.x"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
         "projen": "^0.71.128"
@@ -3034,10 +3034,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.79",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.79.tgz",
-      "integrity": "sha512-Qd7jdLR5zmnIyMhfDrfPqN5tUCvreVpP3Qrf2oSM+F7SNzlb/MwHISGUkdFHtevfkPJ3iAGyeQI/jsbh9EStgQ==",
-      "dev": true
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.11",
@@ -10694,6 +10697,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/eslint": "8.40.0",
     "@types/jest": "29",
     "@types/jscodeshift": "^0.11.6",
-    "@types/node": "^16",
+    "@types/node": "^20",
     "@types/node-fetch": "^2.6.6",
     "@types/prettier": "2.6.0",
     "@typescript-eslint/eslint-plugin": "6",
@@ -80,7 +80,7 @@
     "@types/babel__traverse": "ts3.9"
   },
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 20.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/apollo-server/__tests__/__snapshots__/index.ts.snap
+++ b/src/apollo-server/__tests__/__snapshots__/index.ts.snap
@@ -18,15 +18,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -40,15 +40,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -62,15 +62,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -347,15 +347,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -384,15 +384,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -406,15 +406,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -428,15 +428,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/src/cdk/__tests__/__snapshots__/index.ts.snap
+++ b/src/cdk/__tests__/__snapshots__/index.ts.snap
@@ -18,15 +18,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -40,15 +40,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -428,15 +428,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -495,15 +495,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -517,15 +517,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/src/common/github/__tests__/__snapshots__/index.ts.snap
+++ b/src/common/github/__tests__/__snapshots__/index.ts.snap
@@ -1049,15 +1049,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -3986,15 +3986,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -4008,15 +4008,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/src/common/github/__tests__/index.ts
+++ b/src/common/github/__tests__/index.ts
@@ -113,7 +113,7 @@ describe('GitHub utils', () => {
         const workflow = YAML.parse(snapshot[testWorkflowPath])
 
         Object.values<Job>(workflow.jobs)
-          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
           .forEach((job) => {
             expect(job!.with!['node-version']).toEqual(nodeVersion)
           })
@@ -126,7 +126,7 @@ describe('GitHub utils', () => {
         const workflow = YAML.parse(snapshot[testWorkflowPath])
 
         Object.values<Job>(workflow.jobs)
-          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
           .forEach((job) => {
             expect(job!.with!['node-version']).toEqual(nodeVersion)
           })
@@ -203,7 +203,7 @@ describe('GitHub utils', () => {
           const workflow = YAML.parse(snapshot[testWorkflowPath])
 
           Object.values<Job>(workflow.jobs)
-            .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+            .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
             .forEach((job) => {
               expect(job!.with!['node-version']).toEqual(nodeVersion)
             })
@@ -216,7 +216,7 @@ describe('GitHub utils', () => {
           const workflow = YAML.parse(snapshot[testWorkflowPath])
 
           Object.values<Job>(workflow.jobs)
-            .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+            .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
             .forEach((job) => {
               expect(job!.with!['node-version']).toEqual(nodeVersion)
             })
@@ -300,7 +300,7 @@ describe('GitHub utils', () => {
         const workflow = YAML.parse(snapshot[workflowPath])
 
         Object.values<Job>(workflow.jobs)
-          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
           .forEach((job) => {
             expect(job!.with!['node-version']).toEqual(nodeVersion)
           })
@@ -313,7 +313,7 @@ describe('GitHub utils', () => {
         const workflow = YAML.parse(snapshot[workflowPath])
 
         Object.values<Job>(workflow.jobs)
-          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
           .forEach((job) => {
             expect(job!.with!['node-version']).toEqual(nodeVersion)
           })

--- a/src/common/github/jobs/__tests__/index.ts
+++ b/src/common/github/jobs/__tests__/index.ts
@@ -23,9 +23,9 @@ describe('GitHub utils', () => {
       const setupNodeSteps = setupNode({projectPackage: project.package})
 
       expect(setupNodeSteps.map((step) => step.uses)).toStrictEqual([
-        'actions/checkout@v3',
-        'actions/setup-node@v3',
-        'actions/cache@v3',
+        'actions/checkout@v4',
+        'actions/setup-node@v4',
+        'actions/cache@v4',
         undefined,
       ])
 
@@ -102,11 +102,11 @@ describe('GitHub utils', () => {
       const setupNodeSteps = setupNode({projectPackage: project.package})
 
       expect(setupNodeSteps.map((step) => step.uses)).toStrictEqual([
-        'actions/checkout@v3',
-        'actions/setup-node@v3',
-        'pnpm/action-setup@v2',
+        'actions/checkout@v4',
+        'actions/setup-node@v4',
+        'pnpm/action-setup@v3',
         undefined,
-        'actions/cache@v3',
+        'actions/cache@v4',
         undefined,
       ])
 
@@ -124,7 +124,7 @@ describe('GitHub utils', () => {
       const pnpmVersion = '8.6.5'
       const project = new TestProject({packageManager: NodePackageManager.PNPM, pnpmVersion})
       const setupNodeSteps = setupNode({projectPackage: project.package})
-      const pnpmSetupStep = setupNodeSteps.find((step) => step.uses === 'pnpm/action-setup@v2')
+      const pnpmSetupStep = setupNodeSteps.find((step) => step.uses === 'pnpm/action-setup@v3')
       expect(pnpmSetupStep).toBeDefined()
       expect(pnpmSetupStep!.with!.version).toEqual(pnpmVersion)
     })

--- a/src/common/github/jobs/lighthouse-job.ts
+++ b/src/common/github/jobs/lighthouse-job.ts
@@ -16,7 +16,7 @@ export const lighthouseJob = (options: NodeJobOptions): Job => {
     {name: 'Run Lighthouse audit', run: `${runScriptCommand} lighthouse`, workingDirectory},
     {
       name: 'Save Lighthouse report as an artifact',
-      uses: 'actions/upload-artifact@v3',
+      uses: 'actions/upload-artifact@v4',
       if: 'always()',
       with: {name: 'lighthouse-report', path: '.lighthouseci/'},
       workingDirectory,

--- a/src/common/github/jobs/setup-node.ts
+++ b/src/common/github/jobs/setup-node.ts
@@ -45,7 +45,7 @@ export interface SetupNodeOptions {
  * The steps include dependency installation and caching.
  */
 export const setupNode = ({
-  nodeVersion = 18,
+  nodeVersion = 20,
   projectPackage,
   ref,
   registryUrl,
@@ -58,9 +58,9 @@ export const setupNode = ({
 
   // ANCHOR Basic setup: checkout and node
   const steps: Array<JobStep> = [
-    {uses: 'actions/checkout@v3', with: {'fetch-depth': 0, ref}},
+    {uses: 'actions/checkout@v4', with: {'fetch-depth': 0, ref}},
     {
-      uses: 'actions/setup-node@v3',
+      uses: 'actions/setup-node@v4',
       with: {'node-version': nodeVersion, 'registry-url': registryUrl, scope},
     },
   ]
@@ -69,7 +69,7 @@ export const setupNode = ({
   if (isPnpm) {
     steps.push(
       {
-        uses: 'pnpm/action-setup@v2',
+        uses: 'pnpm/action-setup@v3',
         name: 'Install pnpm',
         id: 'pnpm-install',
         with: {version: pnpmVersion, run_install: false},
@@ -88,7 +88,7 @@ export const setupNode = ({
     {
       id: 'cache-deps',
       name: 'Cache node_modules',
-      uses: 'actions/cache@v3',
+      uses: 'actions/cache@v4',
       with: {key: `\${{ hashFiles('${directory}/${lockFile}') }}`, path: cachePath},
     },
     {

--- a/src/common/telemetry/collect-telemetry/__tests__/index.ts
+++ b/src/common/telemetry/collect-telemetry/__tests__/index.ts
@@ -243,17 +243,17 @@ describe('collectTelemetry function', () => {
           runsOn: ['ubuntu-latest'],
           steps: [
             {
-              uses: 'actions/checkout@v3',
+              uses: 'actions/checkout@v4',
               with: {'fetch-depth': 0},
             },
             {
-              uses: 'actions/setup-node@v3',
-              with: {'node-version': 18},
+              uses: 'actions/setup-node@v4',
+              with: {'node-version': 20},
             },
             {
               id: 'cache-deps',
               name: 'Cache node_modules',
-              uses: 'actions/cache@v3',
+              uses: 'actions/cache@v4',
               with: {
                 key: "${{ hashFiles('./yarn.lock') }}",
                 path: './node_modules',

--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -18,15 +18,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -40,15 +40,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -62,15 +62,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -407,15 +407,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -444,15 +444,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -466,15 +466,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -488,15 +488,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 12.22.0
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules

--- a/src/playwright/github/__tests__/__snapshots__/index.ts.snap
+++ b/src/playwright/github/__tests__/__snapshots__/index.ts.snap
@@ -114,15 +114,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('e2e/package-lock.json') }}
           path: e2e/node_modules

--- a/src/playwright/github/__tests__/index.ts
+++ b/src/playwright/github/__tests__/index.ts
@@ -78,7 +78,7 @@ describe('PlaywrightWorkflowTest', () => {
       const workflow = YAML.parse(snapshot[testWorkflowPath])
 
       Object.values<Job>(workflow.jobs)
-        .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+        .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
         .forEach((job) => {
           expect(job!.with!['node-version']).toEqual(nodeVersion)
         })
@@ -91,7 +91,7 @@ describe('PlaywrightWorkflowTest', () => {
       const workflow = YAML.parse(snapshot[testWorkflowPath])
 
       Object.values<Job>(workflow.jobs)
-        .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+        .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
         .forEach((job) => {
           expect(job!.with!['node-version']).toEqual(nodeVersion)
         })
@@ -159,7 +159,7 @@ describe('PlaywrightWorkflowTest', () => {
         const workflow = YAML.parse(snapshot[testWorkflowPath])
 
         Object.values<Job>(workflow.jobs)
-          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
           .forEach((job) => {
             expect(job!.with!['node-version']).toEqual(nodeVersion)
           })
@@ -172,7 +172,7 @@ describe('PlaywrightWorkflowTest', () => {
         const workflow = YAML.parse(snapshot[testWorkflowPath])
 
         Object.values<Job>(workflow.jobs)
-          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v3`))
+          .map((job) => job.steps.find((step) => step.uses === `actions/setup-node@v4`))
           .forEach((job) => {
             expect(job!.with!['node-version']).toEqual(nodeVersion)
           })

--- a/src/sst/__tests__/__snapshots__/index.ts.snap
+++ b/src/sst/__tests__/__snapshots__/index.ts.snap
@@ -18,15 +18,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -40,15 +40,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -62,15 +62,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -325,15 +325,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -392,15 +392,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -414,15 +414,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules
@@ -436,15 +436,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache node_modules
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: \${{ hashFiles('./package-lock.json') }}
           path: ./node_modules


### PR DESCRIPTION
The GitHub actions in the last vesting have migrated its infrastructure to NodeJS@20. Hence along with the actions update, move the workflows to NodeJS@20 as well.

Closes PLA-298.