### PR TITLE
Use node@20 in github workflows within nextjs project

### DIFF
--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4
@@ -411,7 +411,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4
@@ -448,7 +448,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4
@@ -470,7 +470,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4
@@ -492,7 +492,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.14.0
+          node-version: "20"
       - name: Cache node_modules
         id: cache-deps
         uses: actions/cache@v4

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -60,7 +60,10 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject implements 
   readonly reportTargetAuthHeaderName?: string
 
   constructor(options: OttofellerNextjsProjectOptions) {
+    const workflowNodeVersion = '20'
+
     super({
+      workflowNodeVersion,
       ...options,
       bundlerOptions: {},
       projenrcTs: true,
@@ -153,9 +156,10 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject implements 
     }
 
     // ANCHOR Github
-    TypeScriptTestWorkflow.addToProject(this, options)
-    ProjenDriftCheckWorkflow.addToProject(this, options)
-    CodeOwners.addToProject(this, options)
+    const githubOptions = {workflowNodeVersion, ...options}
+    TypeScriptTestWorkflow.addToProject(this, githubOptions)
+    ProjenDriftCheckWorkflow.addToProject(this, githubOptions)
+    CodeOwners.addToProject(this, githubOptions)
 
     // ANCHOR Set up GraphQL
     const isGraphqlEnabled = options.isGraphqlEnabled ?? true


### PR DESCRIPTION
Only `nextjs` projects is updated, cause it is the only one that has `minNodeVersion` set and picks that version when `workflowNodeVerison` is undefined. All other projects already use node@20 by default.

Closes PLA-302.