### PR TITLE
Make workflows inherit from GithubWorkflow class

### DIFF
--- a/src/common/github/rust-test-workflow.ts
+++ b/src/common/github/rust-test-workflow.ts
@@ -152,6 +152,6 @@ export class RustTestWorkflow extends GithubWorkflow {
       return
     }
 
-    new RustTestWorkflow(githubInstance, {})
+    return new RustTestWorkflow(githubInstance, {})
   }
 }


### PR DESCRIPTION
Thus a project contains less intermediary components.

In addition change return type of all addToProject static methods - now they return the created workflow, if any.

Closes PLA-303.