### PR TITLE
Fix build command in nextjs template

### DIFF
--- a/src/nextjs/__tests__/__snapshots__/index.ts.snap
+++ b/src/nextjs/__tests__/__snapshots__/index.ts.snap
@@ -843,7 +843,13 @@ tsconfig.tsbuildinfo
         "name": "build",
         "steps": [
           {
-            "exec": "default && compile && test",
+            "spawn": "default",
+          },
+          {
+            "spawn": "compile",
+          },
+          {
+            "spawn": "test",
           },
         ],
       },

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -120,7 +120,7 @@ export class OttofellerNextjsProject extends NextJsTypeScriptProject implements 
     // Rename "server" task to "start"
     this.removeTask('server')
 
-    addTaskOrScript(this, 'build', {exec: `${this.ejected ? '' : 'default && '}compile && test`})
+    addTaskOrScript(this, 'build', {steps: [...(this.ejected ? [] : [{spawn: 'default'}]), {spawn: 'compile'}]})
     addTaskOrScript(this, 'compile', {exec: 'tsc --build && next build'})
     addTaskOrScript(this, 'dev', {exec: 'next dev'})
     addTaskOrScript(this, 'export', {exec: 'next export'})

--- a/src/nextjs/jest.ts
+++ b/src/nextjs/jest.ts
@@ -30,4 +30,6 @@ export function setupJest(
 
   addTaskOrScript(project, testTaskName, {exec: 'jest --no-cache --all'})
   addTaskOrScript(project, 'test-unit:watch', {exec: 'jest --watch'})
+
+  project.tasks.tryFind('build')?.spawn(project.tasks.tryFind(testTaskName)!)
 }


### PR DESCRIPTION
Since the command used `spawn` form but was rendered into an `exec` directive, the call to the task resulted in an error. Switching to `spawn` fixes the issue.

Closes PLA-304.