### PR TITLE
Fall back to NodeJS@16 in publish action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,3 +101,4 @@ jobs:
           registry-url: https://registry.npmjs.org/
           npm-token: ${{ secrets.NPM_TOKEN }}
           include-build-step: true
+          node-version: 16

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -155,6 +155,8 @@ publishReleaseGithubWorkflow.addJobs({
           'registry-url': 'https://registry.npmjs.org/',
           'npm-token': '${{ secrets.NPM_TOKEN }}',
           'include-build-step': true,
+          // FIXME: v16 is a workaround with the problem revealed on v20: deps are not bundled upon publish.
+          'node-version': 16,
         },
       },
     ]),


### PR DESCRIPTION
Somehow v20 does not bundle dependencies, which causes the package to fail to bootstrap any project

Closes PLA-317.