### PR TITLE
Update publish flow: bundled deps and nodes version

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,4 +101,3 @@ jobs:
           registry-url: https://registry.npmjs.org/
           npm-token: ${{ secrets.NPM_TOKEN }}
           include-build-step: true
-          node-version: 16

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -26,10 +26,6 @@
       "type": "build"
     },
     {
-      "name": "@types/node-fetch",
-      "type": "build"
-    },
-    {
       "name": "@types/node",
       "version": "^20",
       "type": "build"
@@ -104,15 +100,6 @@
       "type": "build"
     },
     {
-      "name": "node-fetch",
-      "version": "2",
-      "type": "build"
-    },
-    {
-      "name": "prettier",
-      "type": "build"
-    },
-    {
       "name": "prettier-plugin-organize-imports",
       "type": "build"
     },
@@ -135,14 +122,6 @@
       "type": "build"
     },
     {
-      "name": "eslint",
-      "type": "bundled"
-    },
-    {
-      "name": "node-fetch",
-      "type": "bundled"
-    },
-    {
       "name": "prettier",
       "type": "bundled"
     },
@@ -153,6 +132,10 @@
     {
       "name": "projen",
       "type": "peer"
+    },
+    {
+      "name": "prettier",
+      "type": "runtime"
     },
     {
       "name": "projen",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -17,17 +17,10 @@ const project = new projen.cdk.JsiiProject({
   packageManager: projen.javascript.NodePackageManager.NPM,
   minNodeVersion: '20.0.0',
 
-  deps: ['projen'],
-  bundledDeps: ['prettier', 'eslint', 'node-fetch'],
+  deps: ['projen', 'prettier'],
+  bundledDeps: ['prettier'],
   peerDeps: ['projen', 'constructs'],
-  devDeps: [
-    '@types/eslint',
-    '@types/jscodeshift',
-    '@types/prettier',
-    '@graphql-codegen/cli',
-    'node-fetch@2',
-    '@types/node-fetch',
-  ],
+  devDeps: ['@types/eslint', '@types/jscodeshift', '@types/prettier', '@graphql-codegen/cli'],
 
   jsiiVersion: '5.3.x',
   typescriptVersion: '5.3.x',
@@ -71,6 +64,12 @@ addLinters({
   lintPaths: ['src'],
   extraEslintConfigs: [{rules}],
 })
+
+/*
+  NPM skips bundling all deps found in dev section.
+  Therefore prettier needs to be removed from the dev list to enable bundling.
+*/
+project.deps.removeDependency('prettier', projen.DependencyType.BUILD)
 
 // ANCHOR Setup git hooks with Husky
 addHusky(project, {huskyRules: {commitMsg: {ignoreBranches: ['main']}}})

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -154,8 +154,6 @@ publishReleaseGithubWorkflow.addJobs({
           'registry-url': 'https://registry.npmjs.org/',
           'npm-token': '${{ secrets.NPM_TOKEN }}',
           'include-build-step': true,
-          // FIXME: v16 is a workaround with the problem revealed on v20: deps are not bundled upon publish.
-          'node-version': 16,
         },
       },
     ]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,11 @@
       "name": "@ottofeller/templates",
       "version": "1.10.7",
       "bundleDependencies": [
-        "eslint",
-        "node-fetch",
         "prettier"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "eslint": "8.42.0",
-        "node-fetch": "^2.7.0",
-        "prettier": "2.8.0",
+        "prettier": "^2.8.7",
         "projen": "^0.80.1"
       },
       "devDependencies": {
@@ -27,7 +23,6 @@
         "@types/jest": "29",
         "@types/jscodeshift": "^0.11.6",
         "@types/node": "^20",
-        "@types/node-fetch": "^2.6.6",
         "@types/prettier": "2.7.3",
         "@typescript-eslint/eslint-plugin": "6",
         "@typescript-eslint/parser": "6",
@@ -43,8 +38,6 @@
         "jsii-diff": "^1.61.0",
         "jsii-pacmak": "^1.61.0",
         "jsii-rosetta": "5.3.x",
-        "node-fetch": "2",
-        "prettier": "2.8.7",
         "prettier-plugin-organize-imports": "3.2.2",
         "projen": "^0.80.1",
         "ts-jest": "29",
@@ -1788,7 +1781,6 @@
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
@@ -1805,7 +1797,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
       "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
-      "inBundle": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1813,7 +1804,6 @@
     "node_modules/@eslint/eslintrc": {
       "version": "2.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1836,7 +1826,6 @@
     "node_modules/@eslint/js": {
       "version": "8.42.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2844,7 +2833,6 @@
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "dev": true,
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -2858,7 +2846,6 @@
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -2871,7 +2858,6 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -3393,7 +3379,6 @@
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3406,7 +3391,6 @@
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3415,7 +3399,6 @@
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3710,16 +3693,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/prettier": {
@@ -4022,7 +3995,6 @@
     "node_modules/acorn": {
       "version": "8.8.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4034,7 +4006,6 @@
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4068,7 +4039,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4111,7 +4081,6 @@
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4120,7 +4089,6 @@
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4153,7 +4121,6 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -4267,12 +4234,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
-      "dev": true
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "node_modules/auto-bind": {
@@ -4436,7 +4397,6 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4492,7 +4452,6 @@
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4634,7 +4593,6 @@
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4703,7 +4661,6 @@
     "node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4933,7 +4890,6 @@
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4945,7 +4901,6 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -4953,18 +4908,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/comment-json": {
       "version": "4.2.3",
@@ -5011,7 +4954,6 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/configstore": {
@@ -5125,7 +5067,6 @@
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5272,7 +5213,6 @@
     "node_modules/debug": {
       "version": "4.3.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -5315,7 +5255,6 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -5508,15 +5447,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/dependency-graph": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
@@ -5575,7 +5505,6 @@
     "node_modules/doctrine": {
       "version": "3.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -5793,7 +5722,6 @@
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5805,7 +5733,6 @@
     "node_modules/eslint": {
       "version": "8.42.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -5985,7 +5912,6 @@
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.1",
       "dev": true,
-      "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5997,7 +5923,6 @@
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.0",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -6013,7 +5938,6 @@
     "node_modules/espree": {
       "version": "9.5.2",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.8.0",
@@ -6042,7 +5966,6 @@
     "node_modules/esquery": {
       "version": "1.5.0",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -6054,7 +5977,6 @@
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -6066,7 +5988,6 @@
     "node_modules/estraverse": {
       "version": "5.3.0",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6083,7 +6004,6 @@
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6171,7 +6091,6 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -6209,13 +6128,11 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/fast-querystring": {
@@ -6245,7 +6162,6 @@
     "node_modules/fastq": {
       "version": "1.13.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6308,7 +6224,6 @@
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -6362,7 +6277,6 @@
     "node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -6378,7 +6292,6 @@
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -6391,7 +6304,6 @@
     "node_modules/flatted": {
       "version": "3.2.7",
       "dev": true,
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -6400,20 +6312,6 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -6432,7 +6330,6 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -6555,7 +6452,6 @@
     "node_modules/glob": {
       "version": "7.2.3",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -6575,7 +6471,6 @@
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6598,7 +6493,6 @@
     "node_modules/globals": {
       "version": "13.20.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -6663,7 +6557,6 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/graphql": {
@@ -6799,7 +6692,6 @@
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6961,7 +6853,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
-      "inBundle": true,
       "engines": {
         "node": ">= 4"
       }
@@ -6978,7 +6869,6 @@
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -7025,7 +6915,6 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7043,7 +6932,6 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -7053,7 +6941,6 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "dev": true,
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -7228,7 +7115,6 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7254,7 +7140,6 @@
     "node_modules/is-glob": {
       "version": "4.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7343,7 +7228,6 @@
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7530,7 +7414,6 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
@@ -8274,7 +8157,6 @@
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8508,7 +8390,6 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
@@ -8526,7 +8407,6 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/json-to-pretty-yaml": {
@@ -8595,7 +8475,6 @@
     "node_modules/levn": {
       "version": "0.4.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -8640,7 +8519,6 @@
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -8666,7 +8544,6 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -8878,27 +8755,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "dev": true,
@@ -8910,7 +8766,6 @@
     "node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -8938,7 +8793,6 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -8950,7 +8804,6 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/no-case": {
@@ -8968,7 +8821,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
-      "inBundle": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9083,7 +8935,6 @@
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9132,7 +8983,6 @@
     "node_modules/optionator": {
       "version": "0.9.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -9181,7 +9031,6 @@
     "node_modules/p-limit": {
       "version": "3.1.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -9196,7 +9045,6 @@
     "node_modules/p-locate": {
       "version": "5.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -9245,7 +9093,6 @@
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -9308,7 +9155,6 @@
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9317,7 +9163,6 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9326,7 +9171,6 @@
     "node_modules/path-key": {
       "version": "3.1.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9457,7 +9301,6 @@
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -9465,7 +9308,6 @@
     },
     "node_modules/prettier": {
       "version": "2.8.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -10312,7 +10154,6 @@
     "node_modules/punycode": {
       "version": "2.1.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10369,7 +10210,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/readable-stream": {
@@ -10531,7 +10371,6 @@
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10573,7 +10412,6 @@
     "node_modules/reusify": {
       "version": "1.0.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -10588,7 +10426,6 @@
     "node_modules/rimraf": {
       "version": "3.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -10640,7 +10477,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
@@ -10756,7 +10592,6 @@
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10768,7 +10603,6 @@
     "node_modules/shebang-regex": {
       "version": "3.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11109,7 +10943,6 @@
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11138,7 +10971,6 @@
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11150,7 +10982,6 @@
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11211,7 +11042,6 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/through": {
@@ -11283,8 +11113,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "inBundle": true
+      "dev": true
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -11450,7 +11279,6 @@
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -11471,7 +11299,6 @@
     "node_modules/type-fest": {
       "version": "0.20.2",
       "dev": true,
-      "inBundle": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -11668,7 +11495,6 @@
     "node_modules/uri-js": {
       "version": "4.4.1",
       "dev": true,
-      "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -11781,15 +11607,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "inBundle": true
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
-      "inBundle": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -11798,7 +11622,6 @@
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11855,7 +11678,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11885,7 +11707,6 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "dev": true,
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -11999,7 +11820,6 @@
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/jest": "29",
     "@types/jscodeshift": "^0.11.6",
     "@types/node": "^20",
-    "@types/node-fetch": "^2.6.6",
     "@types/prettier": "2.7.3",
     "@typescript-eslint/eslint-plugin": "6",
     "@typescript-eslint/parser": "6",
@@ -55,8 +54,6 @@
     "jsii-diff": "^1.61.0",
     "jsii-pacmak": "^1.61.0",
     "jsii-rosetta": "5.3.x",
-    "node-fetch": "2",
-    "prettier": "2.8.7",
     "prettier-plugin-organize-imports": "3.2.2",
     "projen": "^0.80.1",
     "ts-jest": "29",
@@ -68,14 +65,10 @@
     "projen": "^0.80.1"
   },
   "dependencies": {
-    "eslint": "8.42.0",
-    "node-fetch": "^2.7.0",
-    "prettier": "2.8.0",
+    "prettier": "^2.8.7",
     "projen": "^0.80.1"
   },
   "bundledDependencies": [
-    "eslint",
-    "node-fetch",
     "prettier"
   ],
   "engines": {

--- a/src/common/telemetry/collect-telemetry/collect-telemetry.ts
+++ b/src/common/telemetry/collect-telemetry/collect-telemetry.ts
@@ -1,6 +1,5 @@
 import {execSync} from 'child_process'
 import * as fs from 'fs'
-import fetch from 'node-fetch'
 import * as path from 'path'
 import {ProjenrcFile} from 'projen'
 import type {NodeProject, NodeProjectOptions} from 'projen/lib/javascript'


### PR DESCRIPTION
Closes PLA-317.

- Remove `eslint` and `node-fetch` from bundled dependencies.
- Keep `prettier` as bundled dependency and remove it from devDependencies - thus enabling it to be bundled under `npm@9+`.
- Update NodeJS version in publish flow - with the new setup it becomes possible to use v20 for publishing.