### PR TITLE
Update husky to v9

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,13 +1,13 @@
-#!/usr/bin/env bash
-. "$(dirname -- "$0")/_/husky.sh"
-
 branch=$(git branch --show-current)
 check_branch () {
-  array=$@
-  if [[ " ${array[*]} " =~ " ${branch} " ]];
-  then return 1;
-  else return 0;
-  fi
+  for i in $@
+  do
+    if [ "$i" = "$branch" ];
+      then return 1;
+    fi
+  done
+  
+  return 0;
 }
 
 if check_branch "main"; then

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -69,6 +69,7 @@
     },
     {
       "name": "husky",
+      "version": "9",
       "type": "build"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint": "8",
         "eslint-plugin-eslint-comments": "3.2.0",
         "eslint-plugin-import": "2.27.5",
-        "husky": "8.0.3",
+        "husky": "9",
         "jest": "29",
         "jest-junit": "^15",
         "jsii": "5.3.x",
@@ -6830,14 +6830,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
+      "integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typecheck": "npx projen typecheck",
     "watch": "npx projen watch",
     "projen": "npx projen",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "author": {
     "name": "ottofeller",
@@ -47,7 +47,7 @@
     "eslint": "8",
     "eslint-plugin-eslint-comments": "3.2.0",
     "eslint-plugin-import": "2.27.5",
-    "husky": "8.0.3",
+    "husky": "9",
     "jest": "29",
     "jest-junit": "^15",
     "jsii": "5.3.x",

--- a/src/common/git/husky/add-husky.ts
+++ b/src/common/git/husky/add-husky.ts
@@ -15,8 +15,8 @@ fi
 `
 
 export const addHusky = (project: NodeProject, options: WithGitHooks): void => {
-  project.addDevDeps('husky')
-  project.addScripts({prepare: 'husky install'})
+  project.addDevDeps('husky@9')
+  project.addScripts({prepare: 'husky'})
   const {commitMsg, checkCargo, huskyCustomRules: huskyCustomRule} = options.huskyRules ?? {commitMsg: true}
   const commitMessageCommands: Array<string> = []
   const preCommitCommands: Array<string> = []

--- a/src/common/git/husky/assets/husky-shell-script-template
+++ b/src/common/git/husky/assets/husky-shell-script-template
@@ -1,13 +1,13 @@
-#!/usr/bin/env bash
-. "$(dirname -- "$0")/_/husky.sh"
-
 branch=$(git branch --show-current)
 check_branch () {
-  array=$@
-  if [[ " ${array[*]} " =~ " ${branch} " ]];
-  then return 1;
-  else return 0;
-  fi
+  for i in $@
+  do
+    if [ "$i" = "$branch" ];
+      then return 1;
+    fi
+  done
+  
+  return 0;
 }
 
 {{COMMAND}}


### PR DESCRIPTION
- Update `husky`;
- remove deprecated code from the hooks;
- make the code in pre-commit hook works with `sh` (the shell used by `husky`).

Closes PLA-329.